### PR TITLE
Fix locked account message at login

### DIFF
--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -402,7 +402,7 @@ bool AuthSocket::_HandleLogonChallenge()
                 if (strcmp((*result)[3].GetString(), get_remote_address().c_str()))
                 {
                     DEBUG_LOG("[AuthChallenge] Account IP differs");
-                    pkt << (uint8) WOW_FAIL_SUSPENDED;
+                    pkt << (uint8)WOW_FAIL_DB_BUSY;
                     locked = true;
                 }
                 else


### PR DESCRIPTION
Use WOW_FAIL_DB_BUSY (0x08) instead of WOW_FAIL_SUSPENDED (0x0C)
It makes more sense in the displayed message.
![image](https://user-images.githubusercontent.com/1208311/111676221-44d2e380-881e-11eb-8486-9db243cdefc8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/12)
<!-- Reviewable:end -->
