### PR TITLE
Update AuthSocket.cpp

### DIFF
--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -713,7 +713,8 @@ bool AuthSocket::_HandleLogonProof()
             if (verify)
             {
                 Field* vf = verify->Fetch();
-                if (strcmp(vf->GetString(), K_hex) == 0)
+                const char *sessionkey = vf->GetString();
+                if (sessionkey && K_hex && strcmp(sessionkey, K_hex) == 0)
                     keyVerified = true;
                 delete verify;
             }


### PR DESCRIPTION
Fixes crash from NULL sessionkey when validating db writes.  Since I'm the only one who ever has these db write delays, I'm probably the only one to ever hit this, but here's the fix anyway!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/19)
<!-- Reviewable:end -->
