### PR TITLE
Harden auth logging around verifier data

### DIFF
--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -446,7 +446,7 @@ bool AuthSocket::_HandleLogonChallenge()
                     std::string databaseV = (*result)[5].GetCppString();
                     std::string databaseS = (*result)[6].GetCppString();
 
-                    DEBUG_LOG("database authentication values: v='%s' s='%s'", databaseV.c_str(), databaseS.c_str());
+                    DEBUG_LOG("database authentication values present: v=%s s=%s", databaseV.size() == s_BYTE_SIZE * 2 ? "yes" : "no", databaseS.size() == s_BYTE_SIZE * 2 ? "yes" : "no");
 
                     // multiply with 2, bytes are stored as hexstring
                     if (databaseV.size() != s_BYTE_SIZE * 2 || databaseS.size() != s_BYTE_SIZE * 2)
@@ -690,10 +690,11 @@ bool AuthSocket::_HandleLogonProof()
         BASIC_LOG("User '%s' successfully authenticated", _login.c_str());
 
         ///- Update the sessionkey, last_ip, last login time and reset number of failed logins in the account table for this account
-        // No SQL injection (escaped user name) and IP address as received by socket
+        // No SQL injection (escaped user name and OS) and IP address as received by socket
         const char* K_hex = K.AsHexStr();
 
         // Use synchronous write to help ensure mangosd gets the correct key
+        LoginDatabase.escape_string(_os);
         LoginDatabase.Execute("START TRANSACTION");
         char updateQuery[512];
         snprintf(updateQuery, sizeof(updateQuery),


### PR DESCRIPTION
## Summary

Removes sensitive SRP6 verifier/salt material from debug auth logs and escapes the client-provided OS field before SQL use.

## Changes

- Replaces the debug log that printed raw `v` and `s` hex strings with a presence/validity-only log.
- Escapes `_os` before embedding it in the authenticated account update query.

## Why

The SRP6 verifier is equivalent to credential-hash material for offline password guessing if logs are exposed. This keeps debug logging useful without writing verifier/salt values to disk.

The `_os` field is small, but client-provided, so escaping it is a defense-in-depth SQL safety fix.

## Testing

- Windows `RelWithDebInfo` `realmd` target build: PASS
- No new warnings
- Manual login smoke test not run in this environment

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/20)
<!-- Reviewable:end -->
