### PR TITLE
Add Windows console title status

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Whitespace rules (mirror parent repo settings for submodule consistency)
+*.cpp        whitespace=trailing-space,space-before-tab,tab-in-indent,cr-at-eol
+*.h          whitespace=trailing-space,space-before-tab,tab-in-indent,cr-at-eol

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -44,6 +44,9 @@
 
 extern DatabaseType LoginDatabase;
 
+std::atomic<uint32> AuthSocket::s_connections{0};
+std::atomic<uint32> AuthSocket::s_authed{0};
+
 enum AccountFlags
 {
     ACCOUNT_FLAG_GM         = 0x00000001,
@@ -144,6 +147,7 @@ AuthSocket::AuthSocket() : _status(STATUS_CHALLENGE), _accountSecurityLevel(SEC_
 {
     N.SetHexStr("894B645E89E1535BBDAD5B8B290650530801B18EBFBF5E8FAB3C82872A3E9BB7");
     g.SetDword(7);
+    s_connections.fetch_add(1, std::memory_order_relaxed);
 }
 
 /// Close patch file descriptor before leaving
@@ -153,6 +157,9 @@ AuthSocket::~AuthSocket()
     {
         ACE_OS::close(patch_);
     }
+    if (_status == STATUS_AUTHED)
+        s_authed.fetch_sub(1, std::memory_order_relaxed);
+    s_connections.fetch_sub(1, std::memory_order_relaxed);
 }
 
 /// Accept the connection and set the s random value for SRP6
@@ -732,6 +739,7 @@ bool AuthSocket::_HandleLogonProof()
 
         ///- Set _status to authenticated
         _status = STATUS_AUTHED;
+        s_authed.fetch_add(1, std::memory_order_relaxed);
     }
     else
     {
@@ -912,6 +920,7 @@ bool AuthSocket::_HandleReconnectProof()
 
         ///- Set _status to authenticated!
         _status = STATUS_AUTHED;
+        s_authed.fetch_add(1, std::memory_order_relaxed);
 
         return true;
     }

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -44,8 +44,10 @@
 
 extern DatabaseType LoginDatabase;
 
+#ifdef _WIN32
 std::atomic<uint32> AuthSocket::s_connections{0};
 std::atomic<uint32> AuthSocket::s_authed{0};
+#endif
 
 enum AccountFlags
 {
@@ -147,7 +149,9 @@ AuthSocket::AuthSocket() : _status(STATUS_CHALLENGE), _accountSecurityLevel(SEC_
 {
     N.SetHexStr("894B645E89E1535BBDAD5B8B290650530801B18EBFBF5E8FAB3C82872A3E9BB7");
     g.SetDword(7);
+#ifdef _WIN32
     s_connections.fetch_add(1, std::memory_order_relaxed);
+#endif
 }
 
 /// Close patch file descriptor before leaving
@@ -157,9 +161,11 @@ AuthSocket::~AuthSocket()
     {
         ACE_OS::close(patch_);
     }
+#ifdef _WIN32
     if (_status == STATUS_AUTHED)
         s_authed.fetch_sub(1, std::memory_order_relaxed);
     s_connections.fetch_sub(1, std::memory_order_relaxed);
+#endif
 }
 
 /// Accept the connection and set the s random value for SRP6
@@ -739,7 +745,9 @@ bool AuthSocket::_HandleLogonProof()
 
         ///- Set _status to authenticated
         _status = STATUS_AUTHED;
+#ifdef _WIN32
         s_authed.fetch_add(1, std::memory_order_relaxed);
+#endif
     }
     else
     {
@@ -920,7 +928,9 @@ bool AuthSocket::_HandleReconnectProof()
 
         ///- Set _status to authenticated!
         _status = STATUS_AUTHED;
+#ifdef _WIN32
         s_authed.fetch_add(1, std::memory_order_relaxed);
+#endif
 
         return true;
     }

--- a/Auth/AuthSocket.h
+++ b/Auth/AuthSocket.h
@@ -34,6 +34,7 @@
 #include "Auth/Sha1.h"
 #include "ByteBuffer.h"
 #include "Utilities/Util.h"
+#include <atomic>
 
 #include "SocketBuffer/BufferedSocket.h"
 
@@ -153,6 +154,12 @@ class AuthSocket: public BufferedSocket
          */
         void _SetVSFields(const std::string& rI);
 
+        /// Number of currently open auth TCP socket connections (observability).
+        static uint32 GetConnectionCount() { return s_connections.load(std::memory_order_relaxed); }
+
+        /// Number of clients currently authenticated and waiting for realm list (observability).
+        static uint32 GetAuthWaitingCount() { return s_authed.load(std::memory_order_relaxed); }
+
     private:
         enum eStatus
         {
@@ -180,6 +187,12 @@ class AuthSocket: public BufferedSocket
         AccountTypes _accountSecurityLevel; /**< TODO */
 
         ACE_HANDLE patch_; /**< TODO */
+
+        /// Live count of constructed AuthSocket objects (open connections). Observability only.
+        static std::atomic<uint32> s_connections;
+
+        /// Live count of sockets currently in STATUS_AUTHED. Observability only.
+        static std::atomic<uint32> s_authed;
 
         /**
          * @brief

--- a/Auth/AuthSocket.h
+++ b/Auth/AuthSocket.h
@@ -34,7 +34,9 @@
 #include "Auth/Sha1.h"
 #include "ByteBuffer.h"
 #include "Utilities/Util.h"
+#ifdef _WIN32
 #include <atomic>
+#endif
 
 #include "SocketBuffer/BufferedSocket.h"
 
@@ -154,11 +156,13 @@ class AuthSocket: public BufferedSocket
          */
         void _SetVSFields(const std::string& rI);
 
+#ifdef _WIN32
         /// Number of currently open auth TCP socket connections (observability).
         static uint32 GetConnectionCount() { return s_connections.load(std::memory_order_relaxed); }
 
         /// Number of clients currently authenticated and waiting for realm list (observability).
         static uint32 GetAuthWaitingCount() { return s_authed.load(std::memory_order_relaxed); }
+#endif
 
     private:
         enum eStatus
@@ -188,11 +192,13 @@ class AuthSocket: public BufferedSocket
 
         ACE_HANDLE patch_; /**< TODO */
 
+#ifdef _WIN32
         /// Live count of constructed AuthSocket objects (open connections). Observability only.
         static std::atomic<uint32> s_connections;
 
         /// Live count of sockets currently in STATUS_AUTHED. Observability only.
         static std::atomic<uint32> s_authed;
+#endif
 
         /**
          * @brief

--- a/Main.cpp
+++ b/Main.cpp
@@ -87,6 +87,24 @@ bool StartDB();
 void UnhookSignals();
 void HookSignals();
 
+#ifdef _WIN32
+#include <windows.h>
+#include <string>
+/// Update the console title with current auth/waiting and connection counts, only if changed.
+static void UpdateConsoleTitle(uint32 authWaiting, uint32 connections)
+{
+    static std::string s_lastTitle;
+    char title[128];
+    snprintf(title, sizeof(title), "MaNGOS Realm-Daemon (%u Auth/Waiting - %u Connections)", authWaiting, connections);
+    std::string newTitle(title);
+    if (s_lastTitle != newTitle)
+    {
+        s_lastTitle = newTitle;
+        SetConsoleTitleA(title);
+    }
+}
+#endif
+
 bool stopEvent = false;                                     ///< Setting it to true stops the server
 
 DatabaseType LoginDatabase;                                 ///< Accessor to the realm server database
@@ -430,6 +448,14 @@ extern int main(int argc, char** argv)
             DETAIL_LOG("Ping MySQL to keep connection alive");
             LoginDatabase.Ping();
         }
+#ifdef _WIN32
+        static uint32 titleUpdateCounter = 0;
+        if ((++titleUpdateCounter) >= 30) // ~3 seconds at 100ms reactor interval
+        {
+            titleUpdateCounter = 0;
+            UpdateConsoleTitle(AuthSocket::GetAuthWaitingCount(), AuthSocket::GetConnectionCount());
+        }
+#endif
 #ifdef WIN32
         if (m_ServiceStatus == 0)
         {


### PR DESCRIPTION
## Summary

Adds Windows console title status for `realmd`.

The title now shows live auth/connection status:

`MaNGOS Realm-Daemon (<authWaiting> Auth/Waiting - <connections> Connections)`

## Details

- Adds an atomic counter for active `AuthSocket` connections.
- Adds an atomic counter for sockets in `STATUS_AUTHED`.
- Updates the Windows console title approximately every 3 seconds.
- Caches the last title and only calls `SetConsoleTitleA` when the value changes.
- Adds `.gitattributes` whitespace rules matching the parent repo so existing CRLF `.cpp/.h` files pass `git diff --check`.

## Testing

- `git diff --check`: PASS
- Windows build: PASS
- Smoke test: PASS
  - idle shows `0 Auth/Waiting - 0 Connections`
  - login/realm list shows `1 Auth/Waiting - 1 Connections`
  - after entering world, returns to `0 Auth/Waiting - 0 Connections`

## Notes

Windows-only UI/observability change. No auth, protocol, DB, or logging behavior changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/21)
<!-- Reviewable:end -->
