### PR TITLE
Install WheatyExceptionReport in realmd

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -69,6 +69,7 @@
 
 #ifdef WIN32
 #include "ServiceWin32.h"
+#include "WheatyExceptionReport.h"
 char serviceName[] = "realmd";
 char serviceLongName[] = "MaNGOS realmd service";
 char serviceDescription[] = "Massive Network Game Object Server";
@@ -154,6 +155,11 @@ void usage(const char* prog)
  */
 extern int main(int argc, char** argv)
 {
+#ifdef _WIN32
+    static WheatyExceptionReport exceptionReport;
+    SetUnhandledExceptionFilter(WheatyExceptionReport::WheatyUnhandledExceptionFilter);
+#endif
+
     ///- Command line parsing
     char const* cfg_file = REALMD_CONFIG_LOCATION;
 


### PR DESCRIPTION
## Summary

Explicitly installs `WheatyExceptionReport` in `realmd` on Windows, matching the existing `mangosd` setup.

## Why

A read-only linkage verification found that `realmd` did not explicitly reference `WheatyExceptionReport`, so MSVC could omit `WheatyExceptionReport.obj` from the final executable. Current `realmd` artifacts lacked WER symbols, the `Crashes` string, and `dbghelp` stack-walk imports.

This change creates a direct Windows-only reference so the crash handler is guaranteed to link and install.

## Verification

- `realmd` RelWithDebInfo build: PASS
- `realmd.pdb` contains `WheatyExceptionReport`: YES
- `realmd.exe` contains `Crashes` string: YES
- `dumpbin /imports realmd.exe` shows:
  - `dbghelp.dll`
  - `SymInitialize`
  - `StackWalk64`
  - `SetUnhandledExceptionFilter`

## Notes

Windows-only crash diagnostics. No auth, DB, config, logging, service behavior, or protocol changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/22)
<!-- Reviewable:end -->
