### PR TITLE
Add scheduled exit support

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -135,7 +135,8 @@ namespace
         uint32 dayOfWeek = 0;
         if (!MaNGOS::ParseScheduledExitUInt32(dayText, dayOfWeek) || dayOfWeek > 6)
         {
-            sLog.outError("ScheduledExit: invalid ScheduledExit.DayOfWeek '%s'; disabling scheduled exit", dayText.c_str());
+            sLog.outError("ScheduledExit: invalid ScheduledExit.DayOfWeek '%s'; "
+                "disabling scheduled exit", dayText.c_str());
             return;
         }
 
@@ -144,7 +145,8 @@ namespace
         uint32 minute = 0;
         if (!MaNGOS::ParseScheduledExitTime(timeText, hour, minute))
         {
-            sLog.outError("ScheduledExit: invalid ScheduledExit.Time '%s'; disabling scheduled exit", timeText.c_str());
+            sLog.outError("ScheduledExit: invalid ScheduledExit.Time '%s'; "
+                "disabling scheduled exit", timeText.c_str());
             return;
         }
 
@@ -152,7 +154,8 @@ namespace
         MaNGOS::ScheduledExitMode mode = MaNGOS::SCHEDULED_EXIT_MODE_RESTART;
         if (!MaNGOS::ParseScheduledExitMode(modeText, mode))
         {
-            sLog.outError("ScheduledExit: invalid ScheduledExit.Mode '%s'; disabling scheduled exit", modeText.c_str());
+            sLog.outError("ScheduledExit: invalid ScheduledExit.Mode '%s'; "
+                "disabling scheduled exit", modeText.c_str());
             return;
         }
 
@@ -162,9 +165,11 @@ namespace
         s_scheduledExit.minute = minute;
         s_scheduledExit.mode = mode;
 
-        if (MaNGOS::MarkScheduledExitHandledIfMatching(s_scheduledExit, safe_localtime(time(NULL)), s_scheduledExitState))
+        if (MaNGOS::MarkScheduledExitHandledIfMatching(
+            s_scheduledExit, safe_localtime(time(NULL)), s_scheduledExitState))
         {
-            sLog.outString("ScheduledExit: startup minute matches configured schedule; suppressing this minute to avoid restart loop");
+            sLog.outString("ScheduledExit: startup minute matches configured "
+                "schedule; suppressing this minute to avoid restart loop");
         }
 
         sLog.outString("ScheduledExit: enabled day=%u time=%02u:%02u mode=%s",
@@ -185,7 +190,8 @@ namespace
             return;
         }
 
-        exitCode = s_scheduledExit.mode == MaNGOS::SCHEDULED_EXIT_MODE_RESTART ? REALMD_RESTART_EXIT_CODE : REALMD_SHUTDOWN_EXIT_CODE;
+        exitCode = s_scheduledExit.mode == MaNGOS::SCHEDULED_EXIT_MODE_RESTART
+            ? REALMD_RESTART_EXIT_CODE : REALMD_SHUTDOWN_EXIT_CODE;
         sLog.outString("ScheduledExit: firing scheduled %s",
             MaNGOS::ScheduledExitModeToString(s_scheduledExit.mode));
         stopEvent = true;

--- a/Main.cpp
+++ b/Main.cpp
@@ -51,6 +51,7 @@
 #include "Auth/AuthSocket.h"
 #include "SystemConfig.h"
 #include "revision_data.h"
+#include "ScheduledExit.h"
 #include "Util.h"
 
 #include <openssl/opensslv.h>
@@ -107,8 +108,89 @@ static void UpdateConsoleTitle(uint32 authWaiting, uint32 connections)
 #endif
 
 bool stopEvent = false;                                     ///< Setting it to true stops the server
+uint8 exitCode = 0;                                         ///< Process exit code
 
 DatabaseType LoginDatabase;                                 ///< Accessor to the realm server database
+
+namespace
+{
+    uint8 const REALMD_SHUTDOWN_EXIT_CODE = 0;
+    uint8 const REALMD_RESTART_EXIT_CODE = 2;
+
+    MaNGOS::ScheduledExitSchedule s_scheduledExit;
+    MaNGOS::ScheduledExitState s_scheduledExitState;
+
+    void LoadScheduledExitConfig()
+    {
+        s_scheduledExit = MaNGOS::ScheduledExitSchedule();
+        s_scheduledExitState = MaNGOS::ScheduledExitState();
+
+        if (!sConfig.GetBoolDefault("ScheduledExit.Enable", false))
+        {
+            sLog.outString("ScheduledExit: disabled");
+            return;
+        }
+
+        std::string dayText = sConfig.GetStringDefault("ScheduledExit.DayOfWeek", "3");
+        uint32 dayOfWeek = 0;
+        if (!MaNGOS::ParseScheduledExitUInt32(dayText, dayOfWeek) || dayOfWeek > 6)
+        {
+            sLog.outError("ScheduledExit: invalid ScheduledExit.DayOfWeek '%s'; disabling scheduled exit", dayText.c_str());
+            return;
+        }
+
+        std::string timeText = sConfig.GetStringDefault("ScheduledExit.Time", "05:00");
+        uint32 hour = 0;
+        uint32 minute = 0;
+        if (!MaNGOS::ParseScheduledExitTime(timeText, hour, minute))
+        {
+            sLog.outError("ScheduledExit: invalid ScheduledExit.Time '%s'; disabling scheduled exit", timeText.c_str());
+            return;
+        }
+
+        std::string modeText = sConfig.GetStringDefault("ScheduledExit.Mode", "restart");
+        MaNGOS::ScheduledExitMode mode = MaNGOS::SCHEDULED_EXIT_MODE_RESTART;
+        if (!MaNGOS::ParseScheduledExitMode(modeText, mode))
+        {
+            sLog.outError("ScheduledExit: invalid ScheduledExit.Mode '%s'; disabling scheduled exit", modeText.c_str());
+            return;
+        }
+
+        s_scheduledExit.enabled = true;
+        s_scheduledExit.dayOfWeek = dayOfWeek;
+        s_scheduledExit.hour = hour;
+        s_scheduledExit.minute = minute;
+        s_scheduledExit.mode = mode;
+
+        if (MaNGOS::MarkScheduledExitHandledIfMatching(s_scheduledExit, safe_localtime(time(NULL)), s_scheduledExitState))
+        {
+            sLog.outString("ScheduledExit: startup minute matches configured schedule; suppressing this minute to avoid restart loop");
+        }
+
+        sLog.outString("ScheduledExit: enabled day=%u time=%02u:%02u mode=%s",
+            s_scheduledExit.dayOfWeek, s_scheduledExit.hour, s_scheduledExit.minute,
+            MaNGOS::ScheduledExitModeToString(s_scheduledExit.mode));
+    }
+
+    void CheckScheduledExit()
+    {
+        if (!s_scheduledExit.enabled || stopEvent)
+        {
+            return;
+        }
+
+        std::tm localTime = safe_localtime(time(NULL));
+        if (!MaNGOS::CheckAndMarkScheduledExit(s_scheduledExit, localTime, s_scheduledExitState))
+        {
+            return;
+        }
+
+        exitCode = s_scheduledExit.mode == MaNGOS::SCHEDULED_EXIT_MODE_RESTART ? REALMD_RESTART_EXIT_CODE : REALMD_SHUTDOWN_EXIT_CODE;
+        sLog.outString("ScheduledExit: firing scheduled %s",
+            MaNGOS::ScheduledExitModeToString(s_scheduledExit.mode));
+        stopEvent = true;
+    }
+}
 
 /**
  * @brief Print command line usage information
@@ -291,6 +373,8 @@ extern int main(int argc, char** argv)
         Log::WaitBeforeContinueIfNeed();
     }
 
+    LoadScheduledExitConfig();
+
     DETAIL_LOG("Using SSL version: %s (Library: %s)", OPENSSL_VERSION_TEXT, SSLeay_version(SSLEAY_VERSION));
 
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
@@ -454,6 +538,8 @@ extern int main(int argc, char** argv)
             DETAIL_LOG("Ping MySQL to keep connection alive");
             LoginDatabase.Ping();
         }
+
+        CheckScheduledExit();
 #ifdef _WIN32
         static uint32 titleUpdateCounter = 0;
         if ((++titleUpdateCounter) >= 30) // ~3 seconds at 100ms reactor interval
@@ -481,7 +567,7 @@ extern int main(int argc, char** argv)
     UnhookSignals();
 
     sLog.outString("Halting process...");
-    return 0;
+    return exitCode;
 }
 
 /// Handle termination signals

--- a/realmd.conf.dist.in
+++ b/realmd.conf.dist.in
@@ -93,6 +93,23 @@ ConfVersion=@MANGOS_REALM_VER@
 #        Default: 20
 #                 0  (Disabled)
 #
+#    ScheduledExit.Enable
+#        Enable scheduled shutdown/restart.
+#        Default: 0
+#
+#    ScheduledExit.DayOfWeek
+#        Day of week for scheduled action.
+#        Convention: 0 = Sunday, 1 = Monday, ... 6 = Saturday.
+#        Default: 3
+#
+#    ScheduledExit.Time
+#        Local server time in HH:MM 24-hour format.
+#        Default: "05:00"
+#
+#    ScheduledExit.Mode
+#        shutdown or restart.
+#        Default: "restart"
+#
 #    WrongPass.MaxCount
 #        Number of login attemps with wrong password before the account or IP is banned
 #        Default: 3  (Never ban)
@@ -126,6 +143,10 @@ UseProcessors          = 0
 ProcessPriority        = 1
 WaitAtStartupError     = 0
 RealmsStateUpdateDelay = 20
+ScheduledExit.Enable    = 0
+ScheduledExit.DayOfWeek = 3
+ScheduledExit.Time      = "05:00"
+ScheduledExit.Mode      = "restart"
 
 WrongPass.MaxCount     = 3
 WrongPass.BanTime      = 300


### PR DESCRIPTION
Add service-side scheduled exit support

Adds disabled-by-default scheduled shutdown/restart support to realmd.

Behavior:
- Adds `ScheduledExit` config support to `realmd.conf.dist`.
- Checks local server wall-clock day and time.
- Supports `ScheduledExit.Mode = "restart"` and `ScheduledExit.Mode = "shutdown"`.
- Exits immediately at the configured scheduled minute.
- Uses exit code `2` for restart and exit code `0` for shutdown.
- Adds startup-minute suppression so a service wrapper/watchdog does not repeatedly restart realmd inside the same scheduled minute.
- No player-facing messages, countdown delay, or Remote Admin dependency.

Validation:
- `realmd` rebuilt successfully.
- `scheduled_exit_tests.exe` passed.
- `git -C src\realmd diff --check` passed, aside from Git’s CRLF normalization warning on `realmd.conf.dist.in`.

Notes:
- This is intentionally service-only behavior. The player-facing countdown and maintenance warning text are handled separately in the mangosd PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/23)
<!-- Reviewable:end -->
