### PR TITLE
Fix realmd exit status when OpenSSL provider startup fails

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -426,7 +426,7 @@ extern int main(int argc, char** argv)
     if (!providerManager.IsInitialized())
     {
         Log::WaitBeforeContinueIfNeed();
-        return 0;
+        return 1;
     }
 
     /// realmd PID file creation


### PR DESCRIPTION
## Summary

Follow-up to the OpenSSL changes associated with the ACE removal.

- Return a non-zero exit code when OpenSSL provider initialization fails.
- Prevent service managers and startup scripts from treating a failed cryptographic startup as successful.
- Keep realmd behaviour consistent with mangosd.

## Testing

- Confirmed invalid `OPENSSL_MODULES` configuration causes realmd to exit with code 1.
- Confirmed normal startup with OpenSSL 3.6.2 loads the default and legacy providers.
- Confirmed realmd reaches its listening state and shuts down cleanly with exit code 0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/29)
<!-- Reviewable:end -->
