### PR TITLE
Harden authentication stream framing and session lifecycle

### DIFF
--- a/Auth/AuthProtocolGuard.cpp
+++ b/Auth/AuthProtocolGuard.cpp
@@ -1,0 +1,170 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "AuthProtocolGuard.h"
+
+#include "AuthCodes.h"
+
+namespace MaNGOS::Auth
+{
+namespace
+{
+FrameDecision Reject(RejectReason reason)
+{
+    return {FrameStatus::Reject, reason, 0};
+}
+
+bool IsState(StreamState actual, StreamState expected)
+{
+    return actual == expected;
+}
+}
+
+FrameDecision InspectFrame(
+    StreamState state, std::uint8_t const* data, std::size_t size)
+{
+    if (size == 0)
+    {
+        return {FrameStatus::Incomplete, RejectReason::None, 0};
+    }
+
+    if (!data)
+    {
+        return Reject(RejectReason::MalformedLength);
+    }
+
+    std::size_t required = 0;
+    switch (data[0])
+    {
+        case CMD_AUTH_LOGON_CHALLENGE:
+        case CMD_AUTH_RECONNECT_CHALLENGE:
+        {
+            if (!IsState(state, StreamState::Challenge))
+            {
+                return Reject(RejectReason::UnauthorizedCommand);
+            }
+
+            if (size < AuthChallengeHeaderSize)
+            {
+                return
+                {
+                    FrameStatus::Incomplete,
+                    RejectReason::None,
+                    AuthChallengeHeaderSize
+                };
+            }
+
+            std::uint16_t const body =
+                static_cast<std::uint16_t>(data[2]) |
+                (static_cast<std::uint16_t>(data[3]) << 8);
+            if (body < AuthChallengeMinimumBodySize)
+            {
+                return Reject(RejectReason::MalformedLength);
+            }
+
+            required = AuthChallengeHeaderSize + body;
+            break;
+        }
+        case CMD_AUTH_LOGON_PROOF:
+        {
+            if (!IsState(state, StreamState::LogonProof))
+            {
+                return Reject(RejectReason::UnauthorizedCommand);
+            }
+            required = AuthLogonProofSize;
+            break;
+        }
+        case CMD_AUTH_RECONNECT_PROOF:
+        {
+            if (!IsState(state, StreamState::ReconnectProof))
+            {
+                return Reject(RejectReason::UnauthorizedCommand);
+            }
+            required = AuthReconnectProofSize;
+            break;
+        }
+        case CMD_REALM_LIST:
+        {
+            if (!IsState(state, StreamState::Authenticated))
+            {
+                return Reject(RejectReason::UnauthorizedCommand);
+            }
+            required = AuthRealmListSize;
+            break;
+        }
+        case CMD_XFER_ACCEPT:
+        {
+            if (!IsState(state, StreamState::Patch))
+            {
+                return Reject(RejectReason::UnauthorizedCommand);
+            }
+            required = AuthXferAcceptSize;
+            break;
+        }
+        case CMD_XFER_RESUME:
+        {
+            if (!IsState(state, StreamState::Patch))
+            {
+                return Reject(RejectReason::UnauthorizedCommand);
+            }
+            required = AuthXferResumeSize;
+            break;
+        }
+        case CMD_XFER_CANCEL:
+        {
+            if (!IsState(state, StreamState::Patch))
+            {
+                return Reject(RejectReason::UnauthorizedCommand);
+            }
+            required = AuthXferCancelSize;
+            break;
+        }
+        default:
+        {
+            return Reject(RejectReason::UnknownCommand);
+        }
+    }
+
+    if (size < required)
+    {
+        return {FrameStatus::Incomplete, RejectReason::None, required};
+    }
+
+    return {FrameStatus::Complete, RejectReason::None, required};
+}
+
+bool CanAppendPending(std::size_t pending, std::size_t incoming)
+{
+    return pending <= MaxPendingInput &&
+           incoming <= MaxPendingInput - pending;
+}
+
+Deadline::Deadline(Clock::time_point start, std::chrono::seconds timeout)
+    : m_deadline(start + timeout), m_active(timeout.count() > 0)
+{
+}
+
+bool Deadline::expired(Clock::time_point now) const
+{
+    return m_active.load(std::memory_order_acquire) && now >= m_deadline;
+}
+
+void Deadline::deactivate()
+{
+    m_active.store(false, std::memory_order_release);
+}
+
+bool Deadline::active() const
+{
+    return m_active.load(std::memory_order_acquire);
+}
+}

--- a/Auth/AuthProtocolGuard.h
+++ b/Auth/AuthProtocolGuard.h
@@ -1,0 +1,89 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef MANGOS_H_AUTHPROTOCOLGUARD
+#define MANGOS_H_AUTHPROTOCOLGUARD
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace MaNGOS::Auth
+{
+enum class StreamState
+{
+    Challenge,
+    LogonProof,
+    ReconnectProof,
+    Patch,
+    Authenticated,
+    Closed
+};
+
+enum class FrameStatus
+{
+    Incomplete,
+    Complete,
+    Reject
+};
+
+enum class RejectReason
+{
+    None,
+    UnknownCommand,
+    UnauthorizedCommand,
+    MalformedLength
+};
+
+struct FrameDecision
+{
+    FrameStatus status;
+    RejectReason reason;
+    std::size_t frameSize;
+};
+
+constexpr std::size_t AuthChallengeHeaderSize = 4;
+constexpr std::size_t AuthChallengeMinimumBodySize = 31;
+constexpr std::size_t AuthLogonProofSize = 75;
+constexpr std::size_t AuthReconnectProofSize = 58;
+constexpr std::size_t AuthRealmListSize = 5;
+constexpr std::size_t AuthXferAcceptSize = 1;
+constexpr std::size_t AuthXferResumeSize = 9;
+constexpr std::size_t AuthXferCancelSize = 1;
+constexpr std::size_t MaxPendingInput =
+    AuthChallengeHeaderSize + std::numeric_limits<std::uint16_t>::max();
+
+FrameDecision InspectFrame(
+    StreamState state, std::uint8_t const* data, std::size_t size);
+
+bool CanAppendPending(std::size_t pending, std::size_t incoming);
+
+class Deadline
+{
+    public:
+        using Clock = std::chrono::steady_clock;
+
+        Deadline(Clock::time_point start, std::chrono::seconds timeout);
+
+        bool expired(Clock::time_point now) const;
+        void deactivate();
+        bool active() const;
+
+    private:
+        Clock::time_point m_deadline;
+        std::atomic<bool> m_active;
+};
+}
+
+#endif

--- a/Auth/AuthServer.cpp
+++ b/Auth/AuthServer.cpp
@@ -31,13 +31,20 @@
 
 #include "net/Server.hpp"
 
+#include <chrono>
 #include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
 
 /// Holds the value-type networking engine, kept in the .cpp so its platform
 /// headers stay out of AuthServer.h (and therefore out of Main.cpp).
 struct AuthServer::Impl
 {
     net::Server server;
+    std::mutex socketsMutex;
+    std::vector<std::weak_ptr<AuthSocket>> sockets;
+    std::chrono::seconds authTimeout{30};
 };
 
 AuthServer::AuthServer()
@@ -50,12 +57,52 @@ AuthServer::~AuthServer()
     Stop();
 }
 
-bool AuthServer::Start(uint16_t port, const std::string& bindIp)
+bool AuthServer::Start(
+    uint16_t port,
+    const std::string& bindIp,
+    std::chrono::seconds authTimeout)
 {
-    return m_impl->server.start(port, []() -> std::shared_ptr<net::ISession>
+    m_impl->authTimeout = authTimeout;
+    Impl* const impl = m_impl.get();
+
+    return m_impl->server.start(port, [impl]() -> std::shared_ptr<net::ISession>
     {
-        return std::make_shared<AuthSocket>();
+        std::shared_ptr<AuthSocket> socket =
+            std::make_shared<AuthSocket>(impl->authTimeout);
+        {
+            std::lock_guard<std::mutex> lock(impl->socketsMutex);
+            impl->sockets.emplace_back(socket);
+        }
+        return socket;
     }, bindIp);
+}
+
+void AuthServer::Update()
+{
+    std::vector<std::shared_ptr<AuthSocket>> sockets;
+    {
+        std::lock_guard<std::mutex> lock(m_impl->socketsMutex);
+        auto socket = m_impl->sockets.begin();
+        while (socket != m_impl->sockets.end())
+        {
+            if (std::shared_ptr<AuthSocket> active = socket->lock())
+            {
+                sockets.push_back(std::move(active));
+                ++socket;
+            }
+            else
+            {
+                socket = m_impl->sockets.erase(socket);
+            }
+        }
+    }
+
+    MaNGOS::Auth::Deadline::Clock::time_point const now =
+        MaNGOS::Auth::Deadline::Clock::now();
+    for (std::shared_ptr<AuthSocket> const& socket : sockets)
+    {
+        socket->ExpireAuthentication(now);
+    }
 }
 
 void AuthServer::Stop()
@@ -63,5 +110,7 @@ void AuthServer::Stop()
     if (m_impl)
     {
         m_impl->server.stop();
+        std::lock_guard<std::mutex> lock(m_impl->socketsMutex);
+        m_impl->sockets.clear();
     }
 }

--- a/Auth/AuthServer.h
+++ b/Auth/AuthServer.h
@@ -29,6 +29,7 @@
 #ifndef MANGOS_H_AUTHSERVER
 #define MANGOS_H_AUTHSERVER
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -52,7 +53,13 @@ class AuthServer
         /// configured BindIP: empty (or "0.0.0.0") listens on every local
         /// interface, otherwise the listener binds that single IPv4/hostname.
         /// @return true on success, false if the port could not be bound.
-        bool Start(uint16_t port, const std::string& bindIp = std::string());
+        bool Start(
+            uint16_t port,
+            const std::string& bindIp = std::string(),
+            std::chrono::seconds authTimeout = std::chrono::seconds(30));
+
+        /// Expire sockets that have not completed authentication in time.
+        void Update();
 
         /// Stop the network engine and join its worker threads.
         void Stop();

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -357,6 +357,8 @@ std::vector<uint8_t> AuthSocket::onData(const uint8_t* data, size_t len)
                 continue;
             }
 
+            // InspectFrame is the primary state gate. Keep this table check as
+            // defense in depth against a future guard/dispatch mismatch.
             if (table[i].status != _status)
             {
                 DEBUG_LOG("[Auth] Received unauthorized command %u, length %u", (uint32)_cmd, (uint32)recv_len());
@@ -1149,11 +1151,11 @@ static uint32 ParseClientIPv4(const std::string& addr)
 bool AuthSocket::_HandleRealmList()
 {
     DEBUG_LOG("Entering _HandleRealmList");
-    if (recv_len() < 5)
+    if (recv_len() < MaNGOS::Auth::AuthRealmListSize)
     {
         return false;
     }
-    recv_skip(5);
+    recv_skip(MaNGOS::Auth::AuthRealmListSize);
 
     ///- Get the user id (else close the connection)
     // No SQL injection (escaped user name)
@@ -1349,7 +1351,7 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid)
 bool AuthSocket::_HandleXferAccept()
 {
     DEBUG_LOG("Entering _HandleXferAccept");
-    recv_skip(1);                                           // CMD_XFER_ACCEPT
+    recv_skip(MaNGOS::Auth::AuthXferAcceptSize);
     return BeginPatchStream(0);
 }
 
@@ -1357,14 +1359,15 @@ bool AuthSocket::_HandleXferAccept()
 bool AuthSocket::_HandleXferResume()
 {
     DEBUG_LOG("Entering _HandleXferResume");
-    if (recv_len() < 9)
+    if (recv_len() < MaNGOS::Auth::AuthXferResumeSize)
     {
         return false;
     }
-    recv_skip(1);                                           // CMD_XFER_RESUME
 
     uint64 start_pos;
-    recv((char*)&start_pos, 8);
+    recv_skip(MaNGOS::Auth::AuthXferResumeSize -
+              sizeof(start_pos));
+    recv((char*)&start_pos, sizeof(start_pos));
     EndianConvert(start_pos);
 
     return BeginPatchStream(start_pos);
@@ -1374,7 +1377,7 @@ bool AuthSocket::_HandleXferResume()
 bool AuthSocket::_HandleXferCancel()
 {
     DEBUG_LOG("Entering _HandleXferCancel");
-    recv_skip(1);                                           // CMD_XFER_CANCEL
+    recv_skip(MaNGOS::Auth::AuthXferCancelSize);
     close_connection();
     return true;
 }

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -1367,7 +1367,7 @@ bool AuthSocket::_HandleXferResume()
     uint64 start_pos;
     recv_skip(MaNGOS::Auth::AuthXferResumeSize -
               sizeof(start_pos));
-    recv((char*)&start_pos, sizeof(start_pos));
+    recv(reinterpret_cast<char*>(&start_pos), sizeof(start_pos));
     EndianConvert(start_pos);
 
     return BeginPatchStream(start_pos);

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -33,6 +33,7 @@
 #include "Realm/RealmList.h"
 #include "AuthSocket.h"
 #include "AuthCodes.h"
+#include "AuthProtocolGuard.h"
 #include "PatchHandler.h"
 
 #include <openssl/md5.h>
@@ -143,8 +144,24 @@ typedef struct AuthHandler
 #pragma pack(pop)
 #endif
 
+static_assert(
+    sizeof(sAuthLogonChallenge_C) ==
+        MaNGOS::Auth::AuthChallengeHeaderSize +
+        MaNGOS::Auth::AuthChallengeMinimumBodySize,
+    "auth challenge wire layout changed");
+static_assert(
+    sizeof(sAuthLogonProof_C) == MaNGOS::Auth::AuthLogonProofSize,
+    "logon proof wire layout changed");
+static_assert(
+    sizeof(sAuthReconnectProof_C) == MaNGOS::Auth::AuthReconnectProofSize,
+    "reconnect proof wire layout changed");
+
 /// Constructor - set the N and g values for SRP6
-AuthSocket::AuthSocket() : _status(STATUS_CHALLENGE), _accountSecurityLevel(SEC_PLAYER), _build(0)
+AuthSocket::AuthSocket(std::chrono::seconds authTimeout)
+    : _status(STATUS_CHALLENGE),
+      m_authDeadline(MaNGOS::Auth::Deadline::Clock::now(), authTimeout),
+      _build(0),
+      _accountSecurityLevel(SEC_PLAYER)
 {
     N.SetHexStr("894B645E89E1535BBDAD5B8B290650530801B18EBFBF5E8FAB3C82872A3E9BB7");
     g.SetDword(7);
@@ -205,6 +222,7 @@ bool AuthSocket::send(const char* buf, size_t len)
 
 void AuthSocket::close_connection()
 {
+    deactivate_auth_deadline();
     if (!m_closed.exchange(true))
     {
         if (m_closer)
@@ -212,6 +230,52 @@ void AuthSocket::close_connection()
             m_closer();
         }
     }
+}
+
+void AuthSocket::onClose()
+{
+    deactivate_auth_deadline();
+    m_closed.store(true);
+}
+
+bool AuthSocket::ExpireAuthentication(
+    MaNGOS::Auth::Deadline::Clock::time_point now)
+{
+    if (!m_authDeadline.expired(now))
+    {
+        return false;
+    }
+
+    DEBUG_LOG("[Auth] Authentication deadline expired for '%s'",
+              get_remote_address().c_str());
+    close_connection();
+    return true;
+}
+
+MaNGOS::Auth::StreamState AuthSocket::stream_state() const
+{
+    switch (_status)
+    {
+        case STATUS_CHALLENGE:
+            return MaNGOS::Auth::StreamState::Challenge;
+        case STATUS_LOGON_PROOF:
+            return MaNGOS::Auth::StreamState::LogonProof;
+        case STATUS_RECON_PROOF:
+            return MaNGOS::Auth::StreamState::ReconnectProof;
+        case STATUS_PATCH:
+            return MaNGOS::Auth::StreamState::Patch;
+        case STATUS_AUTHED:
+            return MaNGOS::Auth::StreamState::Authenticated;
+        case STATUS_CLOSED:
+            return MaNGOS::Auth::StreamState::Closed;
+    }
+
+    return MaNGOS::Auth::StreamState::Closed;
+}
+
+void AuthSocket::deactivate_auth_deadline()
+{
+    m_authDeadline.deactivate();
 }
 
 /// Log the accepted connection (net thread, once, before any client bytes).
@@ -229,10 +293,21 @@ std::vector<uint8_t> AuthSocket::onData(const uint8_t* data, size_t len)
         return {};
     }
 
-    // Append newly received bytes to the pending buffer, then run the command
-    // loop over it. TCP is a stream, so a handler may find the buffer short and
-    // bail; anything not consumed this pass stays buffered for the next onData().
-    m_readBuf.insert(m_readBuf.end(), data, data + len);
+    if (!MaNGOS::Auth::CanAppendPending(m_readBuf.size(), len))
+    {
+        DEBUG_LOG("[Auth] Closing connection: pending input limit exceeded");
+        m_readBuf.clear();
+        m_readPos = 0;
+        close_connection();
+        return {};
+    }
+
+    // Append newly received bytes to the pending buffer, then preflight complete
+    // protocol frames before a handler is allowed to consume any bytes.
+    if (len > 0)
+    {
+        m_readBuf.insert(m_readBuf.end(), data, data + len);
+    }
     m_readPos = 0;
 
     const static AuthHandler table[] =
@@ -252,10 +327,26 @@ std::vector<uint8_t> AuthSocket::onData(const uint8_t* data, size_t len)
 
     while (!m_closed.load())
     {
-        if (!recv_soft((char*)&_cmd, 1))
+        MaNGOS::Auth::FrameDecision const decision =
+            MaNGOS::Auth::InspectFrame(
+                stream_state(), m_readBuf.data() + m_readPos, recv_len());
+
+        if (decision.status == MaNGOS::Auth::FrameStatus::Incomplete)
         {
             break;
         }
+        if (decision.status == MaNGOS::Auth::FrameStatus::Reject)
+        {
+            DEBUG_LOG("[Auth] Closing rejected auth stream, reason %u",
+                      static_cast<unsigned>(decision.reason));
+            m_readBuf.clear();
+            m_readPos = 0;
+            close_connection();
+            return {};
+        }
+
+        _cmd = m_readBuf[m_readPos];
+        size_t const frameStart = m_readPos;
 
         size_t i;
         ///- Circle through known commands and call the correct command handler
@@ -269,7 +360,7 @@ std::vector<uint8_t> AuthSocket::onData(const uint8_t* data, size_t len)
             if (table[i].status != _status)
             {
                 DEBUG_LOG("[Auth] Received unauthorized command %u, length %u", (uint32)_cmd, (uint32)recv_len());
-                i = AUTH_TOTAL_COMMANDS;    // force loop exit below
+                i = AUTH_TOTAL_COMMANDS;
                 break;
             }
 
@@ -277,15 +368,25 @@ std::vector<uint8_t> AuthSocket::onData(const uint8_t* data, size_t len)
             if (!(*this.*table[i].handler)())
             {
                 DEBUG_LOG("[Auth] Command handler failed for cmd %u, length %u", (uint32)_cmd, (uint32)recv_len());
-                i = AUTH_TOTAL_COMMANDS;    // force loop exit below
+                i = AUTH_TOTAL_COMMANDS;
+                break;
+            }
+
+            if (m_readPos - frameStart != decision.frameSize)
+            {
+                DEBUG_LOG("[Auth] Handler consumed an unexpected frame length");
+                i = AUTH_TOTAL_COMMANDS;
             }
             break;
         }
 
-        ///- Report unknown / unauthorized / failed commands and stop processing
+        ///- A preflighted command must be handled fully or the stream is closed.
         if (i == AUTH_TOTAL_COMMANDS)
         {
-            DEBUG_LOG("[Auth] Stop processing at command %u", (uint32)_cmd);
+            DEBUG_LOG("[Auth] Closing connection at command %u", (uint32)_cmd);
+            m_readBuf.clear();
+            m_readPos = 0;
+            close_connection();
             break;
         }
     }
@@ -395,11 +496,9 @@ bool AuthSocket::_HandleLogonChallenge()
 
     recv((char*)&buf[0], 4);
 
-#ifdef MANGOS_BIGENDIAN
-    EndianConvert(*((uint16*)(buf[0])));
-#endif
-
-    uint16 remaining = ((sAuthLogonChallenge_C*)&buf[0])->size;
+    uint16 const remaining =
+        static_cast<uint16>(buf[2]) |
+        (static_cast<uint16>(buf[3]) << 8);
     DEBUG_LOG("[AuthChallenge] got header, body is %#04x bytes", remaining);
 
     if ((remaining < sizeof(sAuthLogonChallenge_C) - buf.size()) || (recv_len() < remaining))
@@ -662,6 +761,7 @@ bool AuthSocket::_HandleLogonProof()
 
             ///- Wait for the client's XFER accept/resume/cancel.
             _status = STATUS_PATCH;
+            deactivate_auth_deadline();
             DEBUG_LOG("[AuthChallenge] offering patch %s (%llu bytes) to build %u",
                       patchFile.c_str(), (unsigned long long)fileSize, _build);
             return true;
@@ -806,6 +906,7 @@ bool AuthSocket::_HandleLogonProof()
 
         ///- Set _status to authenticated
         _status = STATUS_AUTHED;
+        deactivate_auth_deadline();
         s_authed.fetch_add(1, std::memory_order_relaxed);
     }
     else
@@ -879,8 +980,9 @@ bool AuthSocket::_HandleReconnectChallenge()
 
     recv((char*)&buf[0], 4);
 
-    EndianConvert(*((uint16*)(buf[0])));
-    uint16 remaining = ((sAuthLogonChallenge_C*)&buf[0])->size;
+    uint16 const remaining =
+        static_cast<uint16>(buf[2]) |
+        (static_cast<uint16>(buf[3]) << 8);
     DEBUG_LOG("[ReconnectChallenge] got header, body is %#04x bytes", remaining);
 
     if ((remaining < sizeof(sAuthLogonChallenge_C) - buf.size()) || (recv_len() < remaining))
@@ -987,6 +1089,7 @@ bool AuthSocket::_HandleReconnectProof()
 
         ///- Set _status to authenticated!
         _status = STATUS_AUTHED;
+        deactivate_auth_deadline();
         s_authed.fetch_add(1, std::memory_order_relaxed);
 
         return true;
@@ -1297,4 +1400,3 @@ bool AuthSocket::BeginPatchStream(uint64 startOffset)
 
     return true;
 }
-

--- a/Auth/AuthSocket.h
+++ b/Auth/AuthSocket.h
@@ -32,12 +32,14 @@
 #include "Common.h"
 #include "Auth/BigNumber.h"
 #include "Auth/Sha1.h"
+#include "AuthProtocolGuard.h"
 #include "ByteBuffer.h"
 #include "Utilities/Util.h"
 
 #include "net/ISession.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -61,7 +63,8 @@ class AuthSocket: public net::ISession
          * @brief
          *
          */
-        AuthSocket();
+        explicit AuthSocket(
+            std::chrono::seconds authTimeout = std::chrono::seconds(30));
 
         /**
          * @brief
@@ -76,8 +79,12 @@ class AuthSocket: public net::ISession
         void setFlowControl(std::shared_ptr<net::FlowControl> fc) override { m_flowControl = std::move(fc); }
         std::vector<uint8_t> onConnect() override;
         std::vector<uint8_t> onData(const uint8_t* data, size_t len) override;
-        void onClose() override { m_closed.store(true); }
+        void onClose() override;
         bool closed() const override { return m_closed.load(); }
+
+        /// Close an unauthenticated connection whose configured deadline elapsed.
+        bool ExpireAuthentication(
+            MaNGOS::Auth::Deadline::Clock::time_point now);
 
         /**
          * @brief
@@ -189,6 +196,8 @@ class AuthSocket: public net::ISession
         bool send(const char* buf, size_t len);
         const std::string& get_remote_address() const { return remote_address_; }
         void close_connection();
+        MaNGOS::Auth::StreamState stream_state() const;
+        void deactivate_auth_deadline();
 
         std::vector<uint8_t> m_readBuf;      ///< pending unconsumed inbound bytes
         size_t               m_readPos = 0;  ///< consume cursor within m_readBuf
@@ -206,6 +215,7 @@ class AuthSocket: public net::ISession
         BigNumber _reconnectProof; /**< TODO */
 
         eStatus _status; /**< TODO */
+        MaNGOS::Auth::Deadline m_authDeadline;
 
         std::string _login; /**< TODO */
         std::string _safelogin; /**< TODO */

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,3 +86,16 @@ if(WIN32 AND MSVC)
         OPTIONAL
         )
 endif()
+
+if(BUILD_TESTING)
+    add_executable(realmd_auth_protocol_tests
+        Tests/AuthProtocolGuardTests.cpp
+        Auth/AuthProtocolGuard.cpp
+    )
+    target_compile_features(realmd_auth_protocol_tests PUBLIC cxx_std_17)
+    set_target_properties(realmd_auth_protocol_tests PROPERTIES CXX_EXTENSIONS OFF)
+    target_include_directories(realmd_auth_protocol_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    add_test(NAME realmd_auth_protocol_tests COMMAND realmd_auth_protocol_tests)
+endif()

--- a/Main.cpp
+++ b/Main.cpp
@@ -556,6 +556,7 @@ extern int main(int argc, char** argv)
     // maximum counter for next ping
     uint32 numLoops = (sConfig.GetIntDefault("MaxPingTime", 30) * (MINUTE * 1000000 / 100000));
     uint32 loopCounter = 0;
+    uint32 logFlushCounter = 0;
 
 #ifndef WIN32
     detachDaemon();
@@ -566,6 +567,12 @@ extern int main(int argc, char** argv)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         authServer.Update();
+
+        if ((++logFlushCounter) >= 10)
+        {
+            logFlushCounter = 0;
+            sLog.Flush();
+        }
 
         if ((++loopCounter) == numLoops)
         {
@@ -605,6 +612,7 @@ extern int main(int argc, char** argv)
     UnhookSignals();
 
     sLog.outString("Halting process...");
+    sLog.Flush();
     return exitCode;
 }
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -426,7 +426,7 @@ extern int main(int argc, char** argv)
     if (!providerManager.IsInitialized())
     {
         Log::WaitBeforeContinueIfNeed();
-        return 0;
+        return 1;
     }
 
     /// realmd PID file creation

--- a/Main.cpp
+++ b/Main.cpp
@@ -473,9 +473,23 @@ extern int main(int argc, char** argv)
     // Honour the configured BindIP: empty or "0.0.0.0" listens on every local
     // interface, otherwise realmd binds only that IPv4/hostname.
     std::string bindIp = sConfig.GetStringDefault("BindIP", "0.0.0.0");
+    int32 const configuredAuthTimeout =
+        sConfig.GetIntDefault("AuthSessionTimeout", 30);
+    uint32 authTimeoutSeconds = 30;
+    if (configuredAuthTimeout < 0)
+    {
+        sLog.outError(
+            "AuthSessionTimeout cannot be negative; using 30 seconds.");
+    }
+    else
+    {
+        authTimeoutSeconds = static_cast<uint32>(configuredAuthTimeout);
+    }
+
     AuthServer authServer;
 
-    if (!authServer.Start(rmport, bindIp))
+    if (!authServer.Start(
+            rmport, bindIp, std::chrono::seconds(authTimeoutSeconds)))
     {
         sLog.outError("MaNGOS realmd can not bind to port %d", rmport);
         Log::WaitBeforeContinueIfNeed();
@@ -551,6 +565,7 @@ extern int main(int argc, char** argv)
     while (!stopEvent)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        authServer.Update();
 
         if ((++loopCounter) == numLoops)
         {

--- a/Tests/AuthProtocolGuardTests.cpp
+++ b/Tests/AuthProtocolGuardTests.cpp
@@ -1,0 +1,208 @@
+#include "Auth/AuthCodes.h"
+#include "Auth/AuthProtocolGuard.h"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+namespace
+{
+int failures = 0;
+
+void Check(bool condition, char const* expression, int line)
+{
+    if (condition)
+    {
+        return;
+    }
+
+    ++failures;
+    std::cerr << "line " << line << ": CHECK failed: " << expression << '\n';
+}
+
+#define CHECK(expression) Check(static_cast<bool>(expression), #expression, __LINE__)
+
+using MaNGOS::Auth::AuthChallengeHeaderSize;
+using MaNGOS::Auth::AuthChallengeMinimumBodySize;
+using MaNGOS::Auth::Deadline;
+using MaNGOS::Auth::FrameStatus;
+using MaNGOS::Auth::InspectFrame;
+using MaNGOS::Auth::MaxPendingInput;
+using MaNGOS::Auth::RejectReason;
+using MaNGOS::Auth::StreamState;
+
+std::vector<std::uint8_t> MakeChallenge(std::uint8_t command,
+                                        std::uint16_t build,
+                                        std::uint16_t bodySize =
+                                            AuthChallengeMinimumBodySize)
+{
+    std::vector<std::uint8_t> frame(AuthChallengeHeaderSize + bodySize, 0);
+    frame[0] = command;
+    frame[2] = static_cast<std::uint8_t>(bodySize & 0xFF);
+    frame[3] = static_cast<std::uint8_t>(bodySize >> 8);
+
+    if (frame.size() > 12)
+    {
+        frame[11] = static_cast<std::uint8_t>(build & 0xFF);
+        frame[12] = static_cast<std::uint8_t>(build >> 8);
+    }
+    return frame;
+}
+
+void CheckChallengeSplits(std::uint8_t command)
+{
+    std::vector<std::uint8_t> const frame = MakeChallenge(command, 5875);
+    for (std::size_t split = 0; split < frame.size(); ++split)
+    {
+        auto const decision =
+            InspectFrame(StreamState::Challenge, frame.data(), split);
+        CHECK(decision.status == FrameStatus::Incomplete);
+    }
+
+    auto const complete =
+        InspectFrame(StreamState::Challenge, frame.data(), frame.size());
+    CHECK(complete.status == FrameStatus::Complete);
+    CHECK(complete.reason == RejectReason::None);
+    CHECK(complete.frameSize == frame.size());
+
+    std::vector<std::uint8_t> coalesced = frame;
+    coalesced.push_back(CMD_AUTH_LOGON_PROOF);
+    auto const first = InspectFrame(
+        StreamState::Challenge, coalesced.data(), coalesced.size());
+    CHECK(first.status == FrameStatus::Complete);
+    CHECK(first.frameSize == frame.size());
+}
+
+void CheckFixedFrame(StreamState state, std::uint8_t command,
+                     std::size_t required)
+{
+    std::vector<std::uint8_t> frame(required, 0);
+    frame[0] = command;
+
+    for (std::size_t split = 0; split < required; ++split)
+    {
+        auto const decision = InspectFrame(state, frame.data(), split);
+        CHECK(decision.status == FrameStatus::Incomplete);
+    }
+
+    auto const complete = InspectFrame(state, frame.data(), frame.size());
+    CHECK(complete.status == FrameStatus::Complete);
+    CHECK(complete.frameSize == required);
+}
+
+void CheckChallengeFraming()
+{
+    CheckChallengeSplits(CMD_AUTH_LOGON_CHALLENGE);
+    CheckChallengeSplits(CMD_AUTH_RECONNECT_CHALLENGE);
+
+    for (std::uint16_t body = 0;
+         body < AuthChallengeMinimumBodySize; ++body)
+    {
+        std::vector<std::uint8_t> const frame =
+            MakeChallenge(CMD_AUTH_LOGON_CHALLENGE, 5875, body);
+        auto const decision =
+            InspectFrame(StreamState::Challenge, frame.data(), frame.size());
+        CHECK(decision.status == FrameStatus::Reject);
+        CHECK(decision.reason == RejectReason::MalformedLength);
+    }
+}
+
+void CheckFixedFraming()
+{
+    CheckFixedFrame(StreamState::LogonProof, CMD_AUTH_LOGON_PROOF,
+                    MaNGOS::Auth::AuthLogonProofSize);
+    CheckFixedFrame(StreamState::ReconnectProof, CMD_AUTH_RECONNECT_PROOF,
+                    MaNGOS::Auth::AuthReconnectProofSize);
+    CheckFixedFrame(StreamState::Authenticated, CMD_REALM_LIST,
+                    MaNGOS::Auth::AuthRealmListSize);
+    CheckFixedFrame(StreamState::Patch, CMD_XFER_ACCEPT,
+                    MaNGOS::Auth::AuthXferAcceptSize);
+    CheckFixedFrame(StreamState::Patch, CMD_XFER_RESUME,
+                    MaNGOS::Auth::AuthXferResumeSize);
+    CheckFixedFrame(StreamState::Patch, CMD_XFER_CANCEL,
+                    MaNGOS::Auth::AuthXferCancelSize);
+}
+
+void CheckRejectedCommands()
+{
+    std::uint8_t const unknown = 0xFF;
+    auto decision =
+        InspectFrame(StreamState::Challenge, &unknown, sizeof(unknown));
+    CHECK(decision.status == FrameStatus::Reject);
+    CHECK(decision.reason == RejectReason::UnknownCommand);
+
+    std::uint8_t const realmList = CMD_REALM_LIST;
+    decision =
+        InspectFrame(StreamState::Challenge, &realmList, sizeof(realmList));
+    CHECK(decision.status == FrameStatus::Reject);
+    CHECK(decision.reason == RejectReason::UnauthorizedCommand);
+}
+
+void CheckPendingLimit()
+{
+    CHECK(MaNGOS::Auth::CanAppendPending(0, MaxPendingInput));
+    CHECK(MaNGOS::Auth::CanAppendPending(MaxPendingInput, 0));
+    CHECK(!MaNGOS::Auth::CanAppendPending(MaxPendingInput, 1));
+    CHECK(!MaNGOS::Auth::CanAppendPending(
+        std::numeric_limits<std::size_t>::max(), 1));
+}
+
+void CheckDeadline()
+{
+    Deadline::Clock::time_point const start{};
+    Deadline deadline(start, std::chrono::seconds(30));
+
+    CHECK(deadline.active());
+    CHECK(!deadline.expired(start + std::chrono::seconds(29)));
+    CHECK(deadline.expired(start + std::chrono::seconds(30)));
+
+    deadline.deactivate();
+    CHECK(!deadline.active());
+    CHECK(!deadline.expired(start + std::chrono::hours(1)));
+
+    Deadline disabled(start, std::chrono::seconds(0));
+    CHECK(!disabled.active());
+    CHECK(!disabled.expired(start + std::chrono::hours(1)));
+}
+
+void CheckBuildIndependentFraming()
+{
+    std::uint16_t const builds[] =
+    {
+        5875, 6005, 6141, 8606, 12340, 15595,
+        18273, 18414, 21742, 26972, 35662, 40000
+    };
+
+    for (std::uint16_t build : builds)
+    {
+        std::vector<std::uint8_t> const frame =
+            MakeChallenge(CMD_AUTH_LOGON_CHALLENGE, build);
+        auto const decision =
+            InspectFrame(StreamState::Challenge, frame.data(), frame.size());
+        CHECK(decision.status == FrameStatus::Complete);
+        CHECK(decision.frameSize == frame.size());
+    }
+}
+}
+
+int main()
+{
+    CheckChallengeFraming();
+    CheckFixedFraming();
+    CheckRejectedCommands();
+    CheckPendingLimit();
+    CheckDeadline();
+    CheckBuildIndependentFraming();
+
+    if (failures != 0)
+    {
+        std::cerr << failures << " auth protocol guard checks failed\n";
+        return 1;
+    }
+
+    std::cout << "auth protocol guard checks passed\n";
+    return 0;
+}

--- a/realmd.conf.dist.in
+++ b/realmd.conf.dist.in
@@ -35,6 +35,12 @@ ConfVersion=@MANGOS_REALM_VER@
 #        Port on which the server will listen
 #        Default: 3724
 #
+#    AuthSessionTimeout
+#        Maximum seconds allowed to complete logon or reconnect authentication.
+#        Authenticated sessions and patch transfers are exempt.
+#        Default: 30
+#                 0 (Disabled)
+#
 #    BindIP
 #        Bind realm list demon to IP/hostname
 #        DO NOT CHANGE THIS UNLESS YOU _REALLY_ KNOW WHAT YOU'RE DOING
@@ -130,6 +136,7 @@ PidFile                = ""
 
 MaxPingTime            = 30
 RealmServerPort        = 3724
+AuthSessionTimeout     = 30
 BindIP                 = "0.0.0.0"
 
 LogLevel               = 0


### PR DESCRIPTION
﻿## Summary

- add a build-independent authentication protocol guard that frames complete commands before dispatch
- reject unknown, unauthorized, malformed, oversized, and handler-failed input deterministically
- expire stalled pre-authentication sessions through a configurable `AuthSessionTimeout`
- align realm-list and patch-transfer consumption with the guard's exact frame sizes
- flush buffered realmd logs periodically and during orderly shutdown
- add focused protocol tests across every accepted client build

## Why

`AuthSocket` previously exposed command handlers directly to arbitrary TCP chunking. A fragmented challenge could be consumed before its full frame arrived, unknown or wrong-state input was not uniformly rejected, pending unauthenticated input had no protocol-level cap, and stalled sessions had no deadline. In addition, the shared logger's 64 KiB buffering was periodically drained by `mangosd` but not by `realmd`, leaving low-volume auth diagnostics invisible until shutdown.

The new guard centralizes state and frame decisions without changing SRP, realm selection, or patch semantics. It remains independent of client expansion; the same `realmd` application continues to handle every supported build.

## Compatibility note

The tested branch is based on Zero's currently compatible realmd line and intentionally does not consume the later parent-header split from realmd PR #27. GitHub's merge calculation against current `master` is clean. This lets Zero pin the tested compatibility commit while the hardening changes are reviewed upstream.

## Validation

- full Zero `RelWithDebInfo` build passed
- CTest: 4/4 passed (`realmd_auth_protocol_tests`, `auth_crypto_tests`, `lease_tests`, `network_regression_tests`)
- protocol tests cover builds 5875, 6005, 6141, 8606, 12340, 15595, 18273, 18414, 21742, 26972, 35662, and 40000
- installed-runtime smoke passed hostile-command rejection, every split of the Classic build-5875 challenge, live debug-log visibility, idle-session timeout, and daemon survival
- manual Classic, TBC, WotLK, and Cata clients authenticated and received realm lists with world servers offline (no character-selection claim)
- cross-model review of the auth-stream package returned `APPROVE` with no blocking or important findings after follow-up

<!-- Reviewable:start -->
- - -
This change is?[<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/30)
<!-- Reviewable:end -->

