### PR TITLE
Harden realm state, session publication, and patch delivery

### DIFF
--- a/Auth/AuthServer.cpp
+++ b/Auth/AuthServer.cpp
@@ -47,6 +47,7 @@ struct AuthServer::Impl
     std::mutex socketsMutex;
     std::vector<std::weak_ptr<AuthSocket>> sockets;
     std::chrono::seconds authTimeout{30};
+    PatchPolicy patchPolicy;
 };
 
 AuthServer::AuthServer()
@@ -62,15 +63,18 @@ AuthServer::~AuthServer()
 bool AuthServer::Start(
     uint16_t port,
     const std::string& bindIp,
-    std::chrono::seconds authTimeout)
+    std::chrono::seconds authTimeout,
+    PatchPolicy patchPolicy)
 {
     m_impl->authTimeout = authTimeout;
+    m_impl->patchPolicy = std::move(patchPolicy);
     Impl* const impl = m_impl.get();
 
     return m_impl->server.start(port, [impl]() -> std::shared_ptr<net::ISession>
     {
         std::shared_ptr<AuthSocket> socket =
-            std::make_shared<AuthSocket>(impl->authTimeout);
+            std::make_shared<AuthSocket>(
+                impl->authTimeout, impl->patchPolicy);
         {
             std::lock_guard<std::mutex> lock(impl->socketsMutex);
             impl->sockets.emplace_back(socket);

--- a/Auth/AuthServer.h
+++ b/Auth/AuthServer.h
@@ -29,6 +29,8 @@
 #ifndef MANGOS_H_AUTHSERVER
 #define MANGOS_H_AUTHSERVER
 
+#include "PatchPolicy.h"
+
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -56,7 +58,8 @@ class AuthServer
         bool Start(
             uint16_t port,
             const std::string& bindIp = std::string(),
-            std::chrono::seconds authTimeout = std::chrono::seconds(30));
+            std::chrono::seconds authTimeout = std::chrono::seconds(30),
+            PatchPolicy patchPolicy = PatchPolicy());
 
         /// Expire sockets that have not completed authentication in time.
         void Update();

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -1211,9 +1211,8 @@ bool AuthSocket::_HandleRealmList()
 
 void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid)
 {
-    RealmList::RealmListIterators iters;
-    iters = sRealmList.GetIteratorsForBuild(_build);
-    uint32 numRealms = sRealmList.NumRealmsForBuild(_build);
+    RealmListView const realms = sRealmList.GetRealmsForBuild(_build);
+    uint32 const numRealms = static_cast<uint32>(realms.size());
 
     uint32 clientIp = ParseClientIPv4(remote_address_);
 
@@ -1226,12 +1225,12 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid)
             pkt << uint32(0);                               // unused value
             pkt << uint8(numRealms);
 
-            for (RealmList::RealmStlList::const_iterator itr = iters.first; itr != iters.second; ++itr)
+            for (Realm const* realm : realms)
             {
                 uint8 AmountOfCharacters;
 
                 // No SQL injection. id of realm is controlled by the database.
-                QueryResult* result = LoginDatabase.PQuery("SELECT `numchars` FROM `realmcharacters` WHERE `realmid` = '%d' AND `acctid`='%u'", (*itr)->m_ID, acctid);
+                QueryResult* result = LoginDatabase.PQuery("SELECT `numchars` FROM `realmcharacters` WHERE `realmid` = '%d' AND `acctid`='%u'", realm->m_ID, acctid);
                 if (result)
                 {
                     Field* fields = result->Fetch();
@@ -1243,18 +1242,18 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid)
                     AmountOfCharacters = 0;
                 }
 
-                bool ok_build = std::find((*itr)->realmbuilds.begin(), (*itr)->realmbuilds.end(), _build) != (*itr)->realmbuilds.end();
+                bool ok_build = std::find(realm->realmbuilds.begin(), realm->realmbuilds.end(), _build) != realm->realmbuilds.end();
 
                 RealmBuildInfo const* buildInfo = ok_build ? FindBuildInfo(_build) : NULL;
                 if (!buildInfo)
                 {
-                    buildInfo = &(*itr)->realmBuildInfo;
+                    buildInfo = &realm->realmBuildInfo;
                 }
 
-                RealmFlags realmflags = (*itr)->realmflags;
+                RealmFlags realmflags = realm->realmflags;
 
                 // 1.x clients not support explicitly REALM_FLAG_SPECIFYBUILD, so manually form similar name as show in more recent clients
-                std::string name = (*itr)->name;
+                std::string name = realm->name;
                 if (realmflags & REALM_FLAG_SPECIFYBUILD)
                 {
                     char buf[20];
@@ -1263,21 +1262,21 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid)
                 }
 
                 // Show offline state for unsupported client builds and locked realms (1.x clients not support locked state show)
-                if (!ok_build || ((*itr)->allowedSecurityLevel > _accountSecurityLevel))
+                if (!ok_build || (realm->allowedSecurityLevel > _accountSecurityLevel))
                 {
                     realmflags = RealmFlags(realmflags | REALM_FLAG_OFFLINE);
                 }
 
-                pkt << uint32((*itr)->icon);                                        // realm type
+                pkt << uint32(realm->icon);                                        // realm type
                 pkt << uint8(realmflags);                                           // realmflags
                 pkt << name;                                                        // name
                 {
-                    RealmAddress srvAddr = GetAddressForClient((**itr), clientIp);
-                    pkt << GetAddressString(srvAddr.ip, (*itr)->ExternalAddress.port);  // address
+                    RealmAddress srvAddr = GetAddressForClient(*realm, clientIp);
+                    pkt << GetAddressString(srvAddr.ip, realm->ExternalAddress.port);  // address
                 }
-                pkt << float((*itr)->populationLevel);
+                pkt << float(realm->populationLevel);
                 pkt << uint8(AmountOfCharacters);
-                pkt << uint8((*itr)->timezone);                                     // realm category
+                pkt << uint8(realm->timezone);                                     // realm category
                 pkt << uint8(0x00);                                                 // unk, may be realm number/id?
             }
 
@@ -1300,12 +1299,12 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid)
             pkt << uint32(0);                               // unused value
             pkt << tempRealm;
 
-            for (RealmList::RealmStlList::const_iterator itr = iters.first; itr != iters.second; ++itr)
+            for (Realm const* realm : realms)
             {
                 uint8 AmountOfCharacters;
 
                 // No SQL injection. id of realm is controlled by the database.
-                QueryResult* result = LoginDatabase.PQuery("SELECT `numchars` FROM `realmcharacters` WHERE `realmid` = '%d' AND `acctid`='%u'", (*itr)->m_ID, acctid);
+                QueryResult* result = LoginDatabase.PQuery("SELECT `numchars` FROM `realmcharacters` WHERE `realmid` = '%d' AND `acctid`='%u'", realm->m_ID, acctid);
                 if (result)
                 {
                     Field* fields = result->Fetch();
@@ -1317,17 +1316,17 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid)
                     AmountOfCharacters = 0;
                 }
 
-                bool ok_build = std::find((*itr)->realmbuilds.begin(), (*itr)->realmbuilds.end(), _build) != (*itr)->realmbuilds.end();
+                bool ok_build = std::find(realm->realmbuilds.begin(), realm->realmbuilds.end(), _build) != realm->realmbuilds.end();
 
                 RealmBuildInfo const* buildInfo = ok_build ? FindBuildInfo(_build) : NULL;
                 if (!buildInfo)
                 {
-                    buildInfo = &(*itr)->realmBuildInfo;
+                    buildInfo = &realm->realmBuildInfo;
                 }
 
-                uint8 lock = ((*itr)->allowedSecurityLevel > _accountSecurityLevel) ? 1 : 0;
+                uint8 lock = (realm->allowedSecurityLevel > _accountSecurityLevel) ? 1 : 0;
 
-                RealmFlags realmFlags = (*itr)->realmflags;
+                RealmFlags realmFlags = realm->realmflags;
 
                 // Show offline state for unsupported client builds
                 if (!ok_build)
@@ -1340,17 +1339,17 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid)
                     realmFlags = RealmFlags(realmFlags & ~REALM_FLAG_SPECIFYBUILD);
                 }
 
-                pkt << uint8((*itr)->icon);                                         // realm type (this is second column in Cfg_Configs.dbc)
+                pkt << uint8(realm->icon);                                         // realm type (this is second column in Cfg_Configs.dbc)
                 pkt << uint8(lock);                                                 // flags, if 0x01, then realm locked
                 pkt << uint8(realmFlags);                                           // see enum RealmFlags
-                pkt << (*itr)->name;                                                // name
+                pkt << realm->name;                                                // name
                 {
-                    RealmAddress srvAddr = GetAddressForClient((**itr), clientIp);
-                    pkt << GetAddressString(srvAddr.ip, (*itr)->ExternalAddress.port);  // address
+                    RealmAddress srvAddr = GetAddressForClient(*realm, clientIp);
+                    pkt << GetAddressString(srvAddr.ip, realm->ExternalAddress.port);  // address
                 }
-                pkt << float((*itr)->populationLevel);
+                pkt << float(realm->populationLevel);
                 pkt << uint8(AmountOfCharacters);
-                pkt << uint8((*itr)->timezone);                                     // realm category (Cfg_Categories.dbc)
+                pkt << uint8(realm->timezone);                                     // realm category (Cfg_Categories.dbc)
                 pkt << uint8(0x2C);                                                 // unk, may be realm number/id?
 
                 if (realmFlags & REALM_FLAG_SPECIFYBUILD)

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -886,39 +886,26 @@ bool AuthSocket::_HandleLogonProof()
         // No SQL injection (escaped user name and OS) and IP address as received by socket
         const char* K_hex = K.AsHexStr();
 
-        // Use synchronous write to help ensure mangosd gets the correct key
         LoginDatabase.escape_string(_os);
-        LoginDatabase.Execute("START TRANSACTION");
-        char updateQuery[512];
-        snprintf(updateQuery, sizeof(updateQuery),
-                "UPDATE `account` SET `sessionkey` = '%s', `last_ip` = '%s', `last_login` = NOW(), `locale` = '%u', `os` = '%s', `failed_logins` = 0 WHERE `username` = '%s'",
-            K_hex, get_remote_address().c_str(), GetLocaleByName(_localizationName), _os.c_str(), _safelogin.c_str());
-        LoginDatabase.Execute(updateQuery);
-        LoginDatabase.Execute("COMMIT");
-        LoginDatabase.Execute("FLUSH TABLES");
-
-        // Verify the new key is available for reads before mangosd tries, gets the old key, and fails
-        bool keyVerified = false;
-        for (int attempts = 0; attempts < 1000 && !keyVerified; attempts++)
+        if (!LoginDatabase.DirectPExecute(
+            "UPDATE `account` SET `sessionkey` = '%s', `last_ip` = '%s', "
+            "`last_login` = NOW(), `locale` = '%u', `os` = '%s', "
+            "`failed_logins` = 0 WHERE `username` = '%s'",
+            K_hex,
+            get_remote_address().c_str(),
+            GetLocaleByName(_localizationName),
+            _os.c_str(),
+            _safelogin.c_str()))
         {
-            QueryResult* verify = LoginDatabase.PQuery("SELECT `sessionkey` FROM `account` WHERE `username` = '%s'", _safelogin.c_str());
-            if (verify)
-            {
-                Field* vf = verify->Fetch();
-                const char *sessionkey = vf->GetString();
-                if (sessionkey && K_hex && strcmp(sessionkey, K_hex) == 0)
-                {
-                    keyVerified = true;
-                }
-                delete verify;
-            }
-            if (!keyVerified)
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(10));
-            }
+            sLog.outError(
+                "[Auth] Failed to publish session key for account %s",
+                _login.c_str());
+            OPENSSL_free(const_cast<char*>(K_hex));
+            close_connection();
+            return false;
         }
-        // Write of new key should be verified, so allow the client to proceed to mangosd
-        OPENSSL_free((void*)K_hex);
+
+        OPENSSL_free(const_cast<char*>(K_hex));
 
         ///- Finish SRP6 and send the final result to the client
         sha.Initialize();

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -55,15 +55,15 @@
 #include "AuthSocket.h"
 #include "AuthCodes.h"
 #include "AuthProtocolGuard.h"
+#include "PatchArtifact.h"
 #include "PatchHandler.h"
 
 #include <openssl/md5.h>
 
 #include <chrono>
 #include <cstring>
-#include <fstream>
 #include <string>
-#include <thread>
+#include <utility>
 
 extern DatabaseType LoginDatabase;
 
@@ -178,9 +178,11 @@ static_assert(
     "reconnect proof wire layout changed");
 
 /// Constructor - set the N and g values for SRP6
-AuthSocket::AuthSocket(std::chrono::seconds authTimeout)
+AuthSocket::AuthSocket(
+    std::chrono::seconds authTimeout, PatchPolicy patchPolicy)
     : _status(STATUS_CHALLENGE),
       m_authDeadline(MaNGOS::Auth::Deadline::Clock::now(), authTimeout),
+      _patchPolicy(std::move(patchPolicy)),
       _build(0),
       _accountSecurityLevel(SEC_PLAYER)
 {
@@ -747,60 +749,6 @@ bool AuthSocket::_HandleLogonProof()
 
     _status = STATUS_CLOSED;
 
-    ///- Check if the client has one of the expected version numbers
-    bool valid_version = FindBuildInfo(_build) != NULL;
-
-    /// <ul><li> If the client has no valid version, offer a patch archive if one
-    /// matching this build+locale is present under ./patches; otherwise reject it.
-    if (!valid_version)
-    {
-        // Archive name mirrors the classic downloader: "<build><locale>.mpq"
-        // (e.g. "5875enGB.mpq"). Kept relative to the working directory as before.
-        std::string patchFile = "./patches/" + std::to_string(_build) + _localizationName + ".mpq";
-
-        uint64 fileSize = 0;
-        {
-            std::ifstream patch(patchFile, std::ios::binary | std::ios::ate);
-            if (patch)
-            {
-                fileSize = uint64(patch.tellg());
-            }
-        }
-
-        XFER_INIT xferh;
-        if (fileSize > 0 && PatchCache::instance()->GetMD5(patchFile, xferh.md5))
-        {
-            xferh.cmd         = CMD_XFER_INITIATE;
-            xferh.fileNameLen = 5;
-            memcpy(xferh.fileName, "Patch", 5);
-            xferh.file_size   = fileSize;
-
-            _patchPath = patchFile;
-
-            ///- Tell the client an update is available, then describe the transfer.
-            uint8 data[2] = { CMD_AUTH_LOGON_PROOF, WOW_FAIL_VERSION_UPDATE };
-            send((const char*)data, sizeof(data));
-            send((const char*)&xferh, sizeof(xferh));
-
-            ///- Wait for the client's XFER accept/resume/cancel.
-            _status = STATUS_PATCH;
-            deactivate_auth_deadline();
-            DEBUG_LOG("[AuthChallenge] offering patch %s (%llu bytes) to build %u",
-                      patchFile.c_str(), (unsigned long long)fileSize, _build);
-            return true;
-        }
-
-        ByteBuffer pkt;
-        pkt << (uint8) CMD_AUTH_LOGON_CHALLENGE;
-        pkt << (uint8) 0x00;
-        pkt << (uint8) WOW_FAIL_VERSION_INVALID;
-        DEBUG_LOG("[AuthChallenge] %u is not a valid client version!", _build);
-        DEBUG_LOG("[AuthChallenge] Patch %s not found", patchFile.c_str());
-        send((char const*)pkt.contents(), pkt.size());
-        return true;
-    }
-    /// </ul>
-
     ///- Continue the SRP6 calculation based on data received from the client
     BigNumber A;
 
@@ -881,6 +829,17 @@ bool AuthSocket::_HandleLogonProof()
     if (!memcmp(M.AsByteArray(), lp.M1, 20))
     {
         BASIC_LOG("User '%s' successfully authenticated", _login.c_str());
+
+        bool const supported = FindBuildInfo(_build) != nullptr;
+        if (_patchPolicy.ShouldPatch(_build, supported))
+        {
+            return OfferPatch();
+        }
+        if (!supported)
+        {
+            SendInvalidVersion();
+            return true;
+        }
 
         ///- Update the sessionkey, last_ip, last login time and reset number of failed logins in the account table for this account
         // No SQL injection (escaped user name and OS) and IP address as received by socket
@@ -1391,7 +1350,7 @@ bool AuthSocket::_HandleXferCancel()
 
 bool AuthSocket::BeginPatchStream(uint64 startOffset)
 {
-    if (_patchPath.empty())
+    if (!m_patchArtifact)
     {
         close_connection();
         return false;
@@ -1401,12 +1360,72 @@ bool AuthSocket::BeginPatchStream(uint64 startOffset)
     // stream is under way (the background thread now owns the send channel).
     _status = STATUS_CLOSED;
 
-    if (!StartPatchTransfer(m_sender, m_closer, m_flowControl, _patchPath, startOffset))
+    if (!StartPatchTransfer(
+        m_sender,
+        m_closer,
+        m_flowControl,
+        std::move(m_patchArtifact),
+        startOffset))
     {
-        sLog.outError("[Patch] failed to open %s for transfer", _patchPath.c_str());
+        sLog.outError(
+            "[Patch] rejected transfer offset %llu for build %u locale %s",
+            static_cast<unsigned long long>(startOffset),
+            _build,
+            _localizationName.c_str());
         close_connection();
         return false;
     }
 
     return true;
+}
+
+bool AuthSocket::OfferPatch()
+{
+    std::string const patchFile =
+        "./patches/" + std::to_string(_build) + _localizationName + ".mpq";
+    std::unique_ptr<PatchArtifact> artifact = PatchArtifact::Open(patchFile);
+    if (!artifact)
+    {
+        sLog.outError("[Patch] required archive cannot be opened: %s",
+            patchFile.c_str());
+        SendInvalidVersion();
+        return true;
+    }
+
+    XFER_INIT transfer{};
+    transfer.cmd = CMD_XFER_INITIATE;
+    transfer.fileNameLen = 5;
+    memcpy(transfer.fileName, "Patch", 5);
+    transfer.file_size = artifact->size();
+    memcpy(
+        transfer.md5,
+        artifact->digest().data(),
+        artifact->digest().size());
+
+    m_patchArtifact = std::move(artifact);
+
+    uint8 data[2] = { CMD_AUTH_LOGON_PROOF, WOW_FAIL_VERSION_UPDATE };
+    send(reinterpret_cast<char const*>(data), sizeof(data));
+    send(reinterpret_cast<char const*>(&transfer), sizeof(transfer));
+
+    _status = STATUS_PATCH;
+    deactivate_auth_deadline();
+    DEBUG_LOG(
+        "[AuthChallenge] offering patch %s (%llu bytes) to build %u",
+        patchFile.c_str(),
+        static_cast<unsigned long long>(transfer.file_size),
+        _build);
+    return true;
+}
+
+void AuthSocket::SendInvalidVersion()
+{
+    ByteBuffer packet;
+    packet << static_cast<uint8>(CMD_AUTH_LOGON_CHALLENGE);
+    packet << static_cast<uint8>(0x00);
+    packet << static_cast<uint8>(WOW_FAIL_VERSION_INVALID);
+    DEBUG_LOG("[AuthChallenge] %u is not a valid client version!", _build);
+    send(
+        reinterpret_cast<char const*>(packet.contents()),
+        packet.size());
 }

--- a/Auth/AuthSocket.h
+++ b/Auth/AuthSocket.h
@@ -36,6 +36,7 @@
 #include "Auth/BigNumber.h"
 #include "Auth/Sha1.h"
 #include "AuthProtocolGuard.h"
+#include "PatchPolicy.h"
 #include "ByteBuffer.h"
 #include "Utilities/Util.h"
 
@@ -49,6 +50,7 @@
 
 struct Realm;
 struct RealmAddress;
+class PatchArtifact;
 
 /**
  * @brief Handle login commands.
@@ -67,7 +69,8 @@ class AuthSocket: public net::ISession
          *
          */
         explicit AuthSocket(
-            std::chrono::seconds authTimeout = std::chrono::seconds(30));
+            std::chrono::seconds authTimeout = std::chrono::seconds(30),
+            PatchPolicy patchPolicy = PatchPolicy());
 
         /**
          * @brief
@@ -186,6 +189,8 @@ class AuthSocket: public net::ISession
         /// Kick off the background patch stream for the offered archive, honouring
         /// an XFER_RESUME start offset. Closes the connection on failure.
         bool BeginPatchStream(uint64 startOffset);
+        bool OfferPatch();
+        void SendInvalidVersion();
 
         // --- Buffered-stream emulation (formerly provided by BufferedSocket) ----
         // net::ISession delivers raw bytes via onData(); these mirror the old
@@ -225,7 +230,8 @@ class AuthSocket: public net::ISession
 
         std::string _localizationName; /**< Since GetLocaleByName() is _NOT_ bijective, we have to store the locale as a string. Otherwise we can't differ between enUS and enGB, which is important for the patch system */
         std::string _os;
-        std::string _patchPath; /**< resolved ./patches archive offered to an unsupported build, empty if none */
+        PatchPolicy _patchPolicy;
+        std::unique_ptr<PatchArtifact> m_patchArtifact;
         uint16 _build; /**< TODO */
         AccountTypes _accountSecurityLevel; /**< TODO */
 

--- a/Auth/PatchArtifact.cpp
+++ b/Auth/PatchArtifact.cpp
@@ -1,0 +1,149 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "PatchArtifact.h"
+
+#include <openssl/evp.h>
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <utility>
+
+namespace
+{
+constexpr std::size_t DigestChunkSize = 4096;
+}
+
+PatchArtifact::PatchArtifact(
+    std::ifstream stream,
+    std::uint64_t size,
+    std::array<std::uint8_t, MD5_DIGEST_LENGTH> digest)
+    : m_stream(std::move(stream)),
+      m_size(size),
+      m_digest(std::move(digest))
+{
+}
+
+std::unique_ptr<PatchArtifact> PatchArtifact::Open(std::string const& path)
+{
+    std::ifstream stream(path, std::ios::binary | std::ios::ate);
+    if (!stream.is_open())
+    {
+        return nullptr;
+    }
+
+    std::streampos const end = stream.tellg();
+    if (end <= std::streampos(0))
+    {
+        return nullptr;
+    }
+
+    std::streamoff const length = end;
+    if (length <= 0 ||
+        static_cast<std::uintmax_t>(length) >
+            std::numeric_limits<std::uint64_t>::max())
+    {
+        return nullptr;
+    }
+    std::uint64_t const size = static_cast<std::uint64_t>(length);
+
+    stream.seekg(0, std::ios::beg);
+    if (!stream.good())
+    {
+        return nullptr;
+    }
+
+    EVP_MD_CTX* context = EVP_MD_CTX_new();
+    if (!context)
+    {
+        return nullptr;
+    }
+
+    if (EVP_DigestInit_ex(context, EVP_md5(), nullptr) != 1)
+    {
+        EVP_MD_CTX_free(context);
+        return nullptr;
+    }
+
+    std::array<char, DigestChunkSize> buffer{};
+    while (stream)
+    {
+        stream.read(buffer.data(), buffer.size());
+        std::streamsize const read = stream.gcount();
+        if (read > 0 &&
+            EVP_DigestUpdate(
+                context, buffer.data(), static_cast<std::size_t>(read)) != 1)
+        {
+            EVP_MD_CTX_free(context);
+            return nullptr;
+        }
+    }
+
+    if (stream.bad())
+    {
+        EVP_MD_CTX_free(context);
+        return nullptr;
+    }
+
+    std::array<std::uint8_t, MD5_DIGEST_LENGTH> digest{};
+    unsigned int digestLength = 0;
+    bool const finalized =
+        EVP_DigestFinal_ex(context, digest.data(), &digestLength) == 1;
+    EVP_MD_CTX_free(context);
+    if (!finalized || digestLength != digest.size())
+    {
+        return nullptr;
+    }
+
+    stream.clear();
+    stream.seekg(0, std::ios::beg);
+    if (!stream.good())
+    {
+        return nullptr;
+    }
+
+    return std::unique_ptr<PatchArtifact>(
+        new PatchArtifact(std::move(stream), size, std::move(digest)));
+}
+
+bool PatchArtifact::Seek(std::uint64_t offset)
+{
+    if (offset > m_size ||
+        offset > static_cast<std::uint64_t>(
+            std::numeric_limits<std::streamoff>::max()))
+    {
+        return false;
+    }
+
+    m_stream.clear();
+    m_stream.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+    return m_stream.good();
+}
+
+std::streamsize PatchArtifact::Read(
+    std::uint8_t* destination, std::size_t capacity)
+{
+    if (!destination || capacity == 0)
+    {
+        return 0;
+    }
+
+    std::size_t const bounded = std::min(
+        capacity,
+        static_cast<std::size_t>(
+            std::numeric_limits<std::streamsize>::max()));
+    m_stream.read(
+        reinterpret_cast<char*>(destination),
+        static_cast<std::streamsize>(bounded));
+    return m_stream.gcount();
+}

--- a/Auth/PatchArtifact.h
+++ b/Auth/PatchArtifact.h
@@ -1,0 +1,56 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef MANGOS_H_PATCHARTIFACT
+#define MANGOS_H_PATCHARTIFACT
+
+#include <openssl/md5.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <string>
+
+class PatchArtifact
+{
+public:
+    static std::unique_ptr<PatchArtifact> Open(std::string const& path);
+
+    PatchArtifact(PatchArtifact&&) = default;
+    PatchArtifact& operator=(PatchArtifact&&) = default;
+    PatchArtifact(PatchArtifact const&) = delete;
+    PatchArtifact& operator=(PatchArtifact const&) = delete;
+
+    std::uint64_t size() const { return m_size; }
+    std::array<std::uint8_t, MD5_DIGEST_LENGTH> const& digest() const
+    {
+        return m_digest;
+    }
+
+    bool Seek(std::uint64_t offset);
+    std::streamsize Read(std::uint8_t* destination, std::size_t capacity);
+    bool bad() const { return m_stream.bad(); }
+
+private:
+    PatchArtifact(
+        std::ifstream stream,
+        std::uint64_t size,
+        std::array<std::uint8_t, MD5_DIGEST_LENGTH> digest);
+
+    std::ifstream m_stream;
+    std::uint64_t m_size;
+    std::array<std::uint8_t, MD5_DIGEST_LENGTH> m_digest;
+};
+
+#endif

--- a/Auth/PatchHandler.cpp
+++ b/Auth/PatchHandler.cpp
@@ -26,19 +26,14 @@
  \ingroup realmd
  */
 
-#include <cstdint>
-#include <string>
-#include <memory>
-#include <mutex>
 #include "PatchHandler.h"
+#include "PatchArtifact.h"
 #include "AuthCodes.h"
 #include "Log.h"
 
-#include <openssl/evp.h>
-
 #include <chrono>
-#include <cstring>
-#include <fstream>
+#include <cstdint>
+#include <memory>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -57,102 +52,22 @@ namespace
     constexpr uint64_t kMaxOutstandingBytes = 256 * 1024;
 }
 
-PatchCache* PatchCache::instance()
-{
-    static PatchCache s_instance;
-    return &s_instance;
-}
-
-bool PatchCache::ComputeMD5(const std::string& fullPath, uint8_t outMd5[MD5_DIGEST_LENGTH])
-{
-    std::ifstream in(fullPath, std::ios::binary);
-    if (!in)
-    {
-        return false;
-    }
-
-    // Streamed, so a large patch is never held in memory: the one-shot EVP_Digest()
-    // cannot express that, hence the explicit context.
-    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
-    if (!ctx)
-    {
-        return false;
-    }
-
-    if (EVP_DigestInit_ex(ctx, EVP_md5(), NULL) != 1)
-    {
-        EVP_MD_CTX_free(ctx);
-        return false;
-    }
-
-    char buf[kChunkSize];
-    while (in)
-    {
-        in.read(buf, sizeof(buf));
-        std::streamsize got = in.gcount();
-        if (got > 0 && EVP_DigestUpdate(ctx, buf, static_cast<size_t>(got)) != 1)
-        {
-            EVP_MD_CTX_free(ctx);
-            return false;
-        }
-    }
-
-    // A read error (as opposed to a clean EOF) leaves a partial hash — reject it.
-    if (in.bad())
-    {
-        EVP_MD_CTX_free(ctx);
-        return false;
-    }
-
-    unsigned int len = 0;
-    const bool ok = EVP_DigestFinal_ex(ctx, outMd5, &len) == 1;
-    EVP_MD_CTX_free(ctx);
-    return ok;
-}
-
-bool PatchCache::GetMD5(const std::string& fullPath, uint8_t outMd5[MD5_DIGEST_LENGTH])
-{
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    auto it = m_cache.find(fullPath);
-    if (it != m_cache.end())
-    {
-        memcpy(outMd5, it->second.data(), MD5_DIGEST_LENGTH);
-        return true;
-    }
-
-    std::array<uint8_t, MD5_DIGEST_LENGTH> digest{};
-    if (!ComputeMD5(fullPath, digest.data()))
-    {
-        return false;
-    }
-
-    m_cache[fullPath] = digest;
-    memcpy(outMd5, digest.data(), MD5_DIGEST_LENGTH);
-    return true;
-}
-
 bool StartPatchTransfer(net::Sender sender, net::Closer closer,
                         std::shared_ptr<net::FlowControl> flow,
-                        const std::string& path, uint64_t startOffset)
+                        std::unique_ptr<PatchArtifact> artifact,
+                        std::uint64_t startOffset)
 {
-    // Open (and position) up front so a failure is reported synchronously to the
-    // caller instead of on the background thread.
-    auto in = std::make_shared<std::ifstream>(path, std::ios::binary);
-    if (!in->is_open())
+    if (!artifact || startOffset > artifact->size())
     {
         return false;
     }
-    if (startOffset != 0)
+    if (!artifact->Seek(startOffset))
     {
-        in->seekg(static_cast<std::streamoff>(startOffset), std::ios::beg);
-        if (!in->good())
-        {
-            return false;
-        }
+        return false;
     }
 
-    std::thread([in, sender = std::move(sender), closer = std::move(closer),
+    std::thread([artifact = std::move(artifact),
+                 sender = std::move(sender), closer = std::move(closer),
                  flow = std::move(flow)]() mutable
     {
         // The classic downloader dislikes data arriving before it has settled on
@@ -173,8 +88,8 @@ bool StartPatchTransfer(net::Sender sender, net::Closer closer,
                 return;
             }
 
-            in->read(reinterpret_cast<char*>(pkt.data() + 3), kChunkSize);
-            std::streamsize got = in->gcount();
+            std::streamsize const got =
+                artifact->Read(pkt.data() + 3, kChunkSize);
             if (got <= 0)
             {
                 break;
@@ -187,7 +102,7 @@ bool StartPatchTransfer(net::Sender sender, net::Closer closer,
             sender(pkt.data(), 3 + static_cast<size_t>(got));
         }
 
-        if (in->bad())
+        if (artifact->bad())
         {
             sLog.outError("PatchTransfer: read error streaming patch, closing connection");
             closer();

--- a/Auth/PatchHandler.h
+++ b/Auth/PatchHandler.h
@@ -29,45 +29,12 @@
 #ifndef MANGOS_H_PATCHHANDLER
 #define MANGOS_H_PATCHHANDLER
 
-#include <memory>
 #include "net/ISession.hpp"
 
-#include <array>
 #include <cstdint>
-#include <map>
-#include <mutex>
-#include <string>
+#include <memory>
 
-#include <openssl/md5.h>
-
-/**
- * @brief Caches the MD5 of client patch archives under ./patches.
- *
- * A build that the server does not support can be lifted to a supported one by
- * dropping a "<build><locale>.mpq" archive in ./patches; realmd streams it to
- * the client (the classic background-downloader flow). The XFER_INITIATE packet
- * carries the archive's MD5 so the client can verify the download, and this
- * cache avoids re-hashing the (potentially large) file on every logon attempt.
- * Thread-safe: the SRP6 handlers run on the network thread and the streaming
- * runs on its own thread.
- */
-class PatchCache
-{
-    public:
-        static PatchCache* instance();
-
-        /// Look up (computing and caching on first use) the MD5 of the patch at
-        /// `fullPath`. Returns false if the file cannot be read.
-        bool GetMD5(const std::string& fullPath, uint8_t outMd5[MD5_DIGEST_LENGTH]);
-
-    private:
-        PatchCache() = default;
-
-        bool ComputeMD5(const std::string& fullPath, uint8_t outMd5[MD5_DIGEST_LENGTH]);
-
-        std::mutex                                                    m_mutex;
-        std::map<std::string, std::array<uint8_t, MD5_DIGEST_LENGTH>> m_cache;
-};
+class PatchArtifact;
 
 /**
  * @brief Stream a patch archive to a client on a detached background thread.
@@ -81,11 +48,14 @@ class PatchCache
  * fully read (to tear the connection down); on success the socket is left open
  * for the client to close once it has the whole archive.
  *
- * @return false if the file cannot be opened at `startOffset` (nothing spawned).
+ * The artifact is the same open stream whose size and digest were advertised.
+ *
+ * @return false if the artifact or resume offset is invalid (nothing spawned).
  */
 bool StartPatchTransfer(net::Sender sender, net::Closer closer,
                         std::shared_ptr<net::FlowControl> flow,
-                        const std::string& path, uint64_t startOffset);
+                        std::unique_ptr<PatchArtifact> artifact,
+                        std::uint64_t startOffset);
 
 #endif
 /// @}

--- a/Auth/PatchPolicy.cpp
+++ b/Auth/PatchPolicy.cpp
@@ -1,0 +1,45 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "PatchPolicy.h"
+
+#include <charconv>
+#include <limits>
+#include <sstream>
+#include <system_error>
+
+std::optional<PatchPolicy> PatchPolicy::Parse(
+    bool enabled, std::string const& forcedBuilds)
+{
+    PatchPolicy policy;
+    policy.m_enabled = enabled;
+
+    std::istringstream tokens(forcedBuilds);
+    std::string token;
+    while (tokens >> token)
+    {
+        std::uint32_t build = 0;
+        auto const parsed =
+            std::from_chars(token.data(), token.data() + token.size(), build);
+        if (parsed.ec != std::errc() ||
+            parsed.ptr != token.data() + token.size() ||
+            build == 0 ||
+            build > std::numeric_limits<std::uint16_t>::max())
+        {
+            return std::nullopt;
+        }
+
+        policy.m_forcedBuilds.insert(static_cast<std::uint16_t>(build));
+    }
+
+    return policy;
+}

--- a/Auth/PatchPolicy.h
+++ b/Auth/PatchPolicy.h
@@ -1,0 +1,40 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef MANGOS_H_PATCHPOLICY
+#define MANGOS_H_PATCHPOLICY
+
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <string>
+
+class PatchPolicy
+{
+public:
+    PatchPolicy() = default;
+
+    static std::optional<PatchPolicy> Parse(
+        bool enabled, std::string const& forcedBuilds);
+
+    bool ShouldPatch(std::uint16_t build, bool supported) const
+    {
+        return m_enabled &&
+            (!supported || m_forcedBuilds.count(build) != 0);
+    }
+
+private:
+    bool m_enabled = true;
+    std::set<std::uint16_t> m_forcedBuilds;
+};
+
+#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,4 +112,10 @@ if(BUILD_TESTING)
         Threads::Threads
     )
     add_test(NAME realmd_realm_snapshot_tests COMMAND realmd_realm_snapshot_tests)
+
+    add_test(NAME realmd_auth_safety_policy
+        COMMAND ${CMAKE_COMMAND}
+            -DREALMD_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/Tests/CheckAuthSafety.cmake
+    )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,4 +118,45 @@ if(BUILD_TESTING)
             -DREALMD_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}
             -P ${CMAKE_CURRENT_SOURCE_DIR}/Tests/CheckAuthSafety.cmake
     )
+
+    add_executable(realmd_patch_safety_tests
+        Tests/PatchSafetyTests.cpp
+        Auth/PatchPolicy.cpp
+        Auth/PatchArtifact.cpp
+    )
+    target_compile_features(realmd_patch_safety_tests PUBLIC cxx_std_17)
+    set_target_properties(realmd_patch_safety_tests PROPERTIES CXX_EXTENSIONS OFF)
+    target_include_directories(realmd_patch_safety_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(realmd_patch_safety_tests PRIVATE
+        mangos_openssl
+        mangos_openssl_strict
+    )
+    if(WIN32)
+        find_file(REALMD_TEST_OPENSSL_CRYPTO_DLL
+            NAMES libcrypto-3-x64.dll libcrypto-3.dll
+            HINTS "${OPENSSL_ROOT_DIR}/bin"
+            NO_DEFAULT_PATH
+        )
+        if(NOT REALMD_TEST_OPENSSL_CRYPTO_DLL)
+            message(FATAL_ERROR
+                "Could not find the OpenSSL 3.x crypto runtime DLL under "
+                "${OPENSSL_ROOT_DIR}/bin")
+        endif()
+        add_custom_command(TARGET realmd_patch_safety_tests POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${REALMD_TEST_OPENSSL_CRYPTO_DLL}"
+                "$<TARGET_FILE_DIR:realmd_patch_safety_tests>"
+            COMMENT
+                "realmd_patch_safety_tests: co-locating the OpenSSL runtime"
+        )
+    endif()
+    add_test(NAME realmd_patch_safety_tests COMMAND realmd_patch_safety_tests)
+
+    add_test(NAME realmd_patch_safety_policy
+        COMMAND ${CMAKE_COMMAND}
+            -DREALMD_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/Tests/CheckPatchSafety.cmake
+    )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,4 +98,18 @@ if(BUILD_TESTING)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
     add_test(NAME realmd_auth_protocol_tests COMMAND realmd_auth_protocol_tests)
+
+    add_executable(realmd_realm_snapshot_tests
+        Tests/RealmSnapshotTests.cpp
+    )
+    target_compile_features(realmd_realm_snapshot_tests PUBLIC cxx_std_17)
+    set_target_properties(realmd_realm_snapshot_tests PROPERTIES CXX_EXTENSIONS OFF)
+    target_include_directories(realmd_realm_snapshot_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(realmd_realm_snapshot_tests PRIVATE
+        shared
+        Threads::Threads
+    )
+    add_test(NAME realmd_realm_snapshot_tests COMMAND realmd_realm_snapshot_tests)
 endif()

--- a/Main.cpp
+++ b/Main.cpp
@@ -52,6 +52,7 @@
 #include "Config/Config.h"
 #include "GitRevision.h"
 #include "Log.h"
+#include "Auth/PatchPolicy.h"
 #include "Auth/AuthSocket.h"
 #include "Auth/AuthServer.h"
 #include "SystemConfig.h"
@@ -66,6 +67,7 @@
 #include <chrono>
 #include <cstring>
 #include <thread>
+#include <utility>
 
 #ifdef WIN32
 #include "ServiceWin32.h"
@@ -489,10 +491,24 @@ extern int main(int argc, char** argv)
         authTimeoutSeconds = static_cast<uint32>(configuredAuthTimeout);
     }
 
+    bool const patchEnabled =
+        sConfig.GetBoolDefault("Patch.Enable", true);
+    auto patchPolicy = PatchPolicy::Parse(
+        patchEnabled,
+        sConfig.GetStringDefault("Patch.ForceBuilds", ""));
+    if (!patchPolicy)
+    {
+        sLog.outError("Invalid Patch.ForceBuilds configuration");
+        return 1;
+    }
+
     AuthServer authServer;
 
     if (!authServer.Start(
-            rmport, bindIp, std::chrono::seconds(authTimeoutSeconds)))
+            rmport,
+            bindIp,
+            std::chrono::seconds(authTimeoutSeconds),
+            std::move(*patchPolicy)))
     {
         sLog.outError("MaNGOS realmd can not bind to port %d", rmport);
         Log::WaitBeforeContinueIfNeed();

--- a/Realm/RealmList.cpp
+++ b/Realm/RealmList.cpp
@@ -133,7 +133,7 @@ RealmBuildInfo const* FindBuildInfo(uint16 _build)
     return NULL;
 }
 
-RealmList::RealmList() : m_UpdateInterval(0), m_NextUpdateTime(time(NULL))
+RealmList::RealmList()
 {
 }
 
@@ -156,44 +156,27 @@ RealmVersion RealmList::BelongsToVersion(uint32 build) const
     }
 }
 
-RealmList::RealmListIterators RealmList::GetIteratorsForBuild(uint32 build) const
+RealmListView RealmList::GetRealmsForBuild(uint32 build) const
 {
-    RealmVersion version = BelongsToVersion(build);
-    if (version >= REALM_VERSION_COUNT)
-    {
-        return RealmListIterators(
-            m_realmsByVersion[0].end(),
-            m_realmsByVersion[0].end()
-            );
-    }
-    return RealmListIterators(
-        m_realmsByVersion[uint32(version)].begin(),
-        m_realmsByVersion[uint32(version)].end()
-        );
-
+    return RealmListView(m_snapshots.Load(), BelongsToVersion(build));
 }
 
 /// Load the realm list from the database
 void RealmList::Initialize(uint32 updateInterval)
 {
-    m_UpdateInterval = updateInterval;
-
     InitBuildToVersion();
 
     ///- Get the content of the realmlist table in the database
-    UpdateRealms(true);
+    m_snapshots.Publish(BuildSnapshot(true));
+    m_refreshGate.Reset(updateInterval, time(NULL));
 }
 
-uint32 RealmList::NumRealmsForBuild(uint32 build) const
-{
-    return m_realmsByVersion[BelongsToVersion(build)].size();
-}
-
-void RealmList::AddRealmToBuildList(const Realm& realm)
+void RealmList::AddRealmToBuildList(
+    RealmSnapshot& snapshot, Realm const& realm)
 {
     RealmBuilds builds = realm.realmbuilds;
     int buildNumber = *(builds.begin());
-    m_realmsByVersion[BelongsToVersion(buildNumber)].push_back(&realm);
+    snapshot.realmsByVersion[BelongsToVersion(buildNumber)].push_back(&realm);
 }
 
 void RealmList::InitBuildToVersion()
@@ -220,10 +203,23 @@ void RealmList::InitBuildToVersion()
     m_buildToVersion[40000] = REALM_VERSION_SHADOWLANDS;
 }
 
-void RealmList::UpdateRealm(uint32 ID, const std::string& name, RealmAddress const& address, RealmAddress const& localAddr, RealmAddress const& localSubmask, uint32 port, uint8 icon, RealmFlags realmflags, uint8 timezone, AccountTypes allowedSecurityLevel, float popu, const std::string& builds)
+void RealmList::UpdateRealm(
+    RealmSnapshot& snapshot,
+    uint32 ID,
+    const std::string& name,
+    RealmAddress const& address,
+    RealmAddress const& localAddr,
+    RealmAddress const& localSubmask,
+    uint32 port,
+    uint8 icon,
+    RealmFlags realmflags,
+    uint8 timezone,
+    AccountTypes allowedSecurityLevel,
+    float popu,
+    const std::string& builds)
 {
     ///- Create new if not exist or update existed
-    Realm& realm = m_realms[name];
+    Realm& realm = snapshot.realms[name];
 
     realm.m_ID       = ID;
     realm.name       = name;
@@ -246,7 +242,7 @@ void RealmList::UpdateRealm(uint32 ID, const std::string& name, RealmAddress con
 
     if (first_build)
     {
-        AddRealmToBuildList(realm);
+        AddRealmToBuildList(snapshot, realm);
     }
     else
     {
@@ -278,28 +274,16 @@ void RealmList::UpdateRealm(uint32 ID, const std::string& name, RealmAddress con
 
 void RealmList::UpdateIfNeed()
 {
-    // maybe disabled or updated recently
-    if (!m_UpdateInterval || m_NextUpdateTime > time(NULL))
+    m_refreshGate.RunIfDue(time(NULL), [this]
     {
-        return;
-    }
-
-    m_NextUpdateTime = time(NULL) + m_UpdateInterval;
-
-    // Clears Realm list
-    m_realms.clear();
-    for (int i = 0; i < REALM_VERSION_COUNT; ++i)
-    {
-        m_realmsByVersion[i].clear();
-    }
-
-    // Get the content of the realmlist table in the database
-    UpdateRealms(false);
+        m_snapshots.Publish(BuildSnapshot(false));
+    });
 }
 
-void RealmList::UpdateRealms(bool init)
+std::shared_ptr<RealmSnapshot> RealmList::BuildSnapshot(bool init)
 {
     DETAIL_LOG("Updating Realm List...");
+    auto snapshot = std::make_shared<RealmSnapshot>();
 
     ////                                               0     1       2          3               4                  5       6       7             8           9                       10            11
     QueryResult* result = LoginDatabase.Query("SELECT `id`, `name`, `address`, `localAddress`, `localSubnetMask`, `port`, `icon`, `realmflags`, `timezone`, `allowedSecurityLevel`, `population`, `realmbuilds` FROM `realmlist` WHERE (`realmflags` & 1) = 0 ORDER BY `name`");
@@ -334,7 +318,7 @@ void RealmList::UpdateRealms(bool init)
                 realmflags &= (REALM_FLAG_OFFLINE | REALM_FLAG_NEW_PLAYERS | REALM_FLAG_RECOMMENDED | REALM_FLAG_SPECIFYBUILD);
             }
 
-            UpdateRealm(Id, name, externalAddr, localAddr, submask, port, icon, RealmFlags(realmflags), timezone, (allowedSecurityLevel <= SEC_ADMINISTRATOR ? AccountTypes(allowedSecurityLevel) : SEC_ADMINISTRATOR), population, realmbuilds);
+            UpdateRealm(*snapshot, Id, name, externalAddr, localAddr, submask, port, icon, RealmFlags(realmflags), timezone, (allowedSecurityLevel <= SEC_ADMINISTRATOR ? AccountTypes(allowedSecurityLevel) : SEC_ADMINISTRATOR), population, realmbuilds);
 
             if (init)
             {
@@ -344,4 +328,6 @@ void RealmList::UpdateRealms(bool init)
         while (result->NextRow());
         delete result;
     }
+
+    return snapshot;
 }

--- a/Realm/RealmList.h
+++ b/Realm/RealmList.h
@@ -29,91 +29,11 @@
 #ifndef MANGOS_H_REALMLIST
 #define MANGOS_H_REALMLIST
 
-#include <utility>
-#include "Common/ServerDefines.h"
-#include "Platform/Define.h"
-#include <ctime>
+#include "RealmSnapshot.h"
+
+#include <memory>
 #include <string>
 #include <map>
-#include <set>
-#include <list>
-
-/**
- * @brief Resolved IPv4 endpoint for a realm.
- *
- * A plain, pre-resolved IPv4 address in host byte order plus a port. @c loopback
- * is precomputed (127.0.0.0/8) so the address-selection logic never needs to
- * re-inspect the octets.
- */
-struct RealmAddress
-{
-    uint32 ip = 0;          ///< IPv4 address in host byte order
-    uint16 port = 0;        ///< TCP port (unused for subnet masks)
-    bool   loopback = false;///< true when @c ip is in 127.0.0.0/8
-};
-
-/**
- * @brief
- *
- */
-struct RealmBuildInfo
-{
-    int build; /**< TODO */
-    int major_version; /**< TODO */
-    int minor_version; /**< TODO */
-    int bugfix_version; /**< TODO */
-    int hotfix_version; /**< TODO */
-};
-
-enum RealmVersion
-{
-    REALM_VERSION_VANILLA     = 0,
-    REALM_VERSION_TBC         = 1,
-    REALM_VERSION_WOTLK       = 2,
-    REALM_VERSION_CATA        = 3,
-    REALM_VERSION_MOP         = 4,
-    REALM_VERSION_WOD         = 5,
-    REALM_VERSION_LEGION      = 6,
-    REALM_VERSION_BFA         = 7,
-    REALM_VERSION_SHADOWLANDS = 8,
-    REALM_VERSION_COUNT       = 9
-};
-
-/**
- * This is used to make a link between build number and actual wow version that
- * it belongs to. To get the connection between them, ie turn a build into a version
- * one would use \ref RealmList::BelongsToVersion the other way around is not available
- * as it does not make sense and isn't needed.
- */
-RealmBuildInfo const* FindBuildInfo(uint16 _build);
-
-/**
- * @brief
- *
- */
-typedef std::set<uint32> RealmBuilds;
-
-/// Storage object for a realm
-
-/**
- * @brief
- *
- */
-struct Realm
-{
-    std::string name;
-    RealmAddress ExternalAddress;
-    RealmAddress LocalAddress;
-    RealmAddress LocalSubnetMask;
-    uint8 icon;
-    RealmFlags realmflags;                                  // realmflags
-    uint8 timezone;
-    uint32 m_ID;
-    AccountTypes allowedSecurityLevel;                      // current allowed join security level (show as locked for not fit accounts)
-    float populationLevel;
-    RealmBuilds realmbuilds;                                // list of supported builds (updated in DB by mangosd)
-    RealmBuildInfo realmBuildInfo;                          // build info for show version in list
-};
 
 /**
  * @brief Storage object for the list of realms on the server
@@ -126,9 +46,6 @@ class RealmList
          * @brief
          *
          */
-        typedef std::map<std::string, Realm> RealmMap;
-        typedef std::list<const Realm*> RealmStlList;
-        typedef std::pair<RealmStlList::const_iterator, RealmStlList::const_iterator> RealmListIterators;
         typedef std::map<uint32, RealmVersion> RealmBuildVersionMap;
 
         static RealmList& Instance();
@@ -146,29 +63,15 @@ class RealmList
 
         void UpdateIfNeed();
 
-        /**
-         * Get's the iterators for all realms supporting the given version as a pair,
-         * the first member is a iterator to the begin() and the second is an iterator
-         * to the end().
-         * @param build the build number to fetch the iterators for
-         * @return iterators to the begin() and end() part of the realms supporting
-         * the given build, if there is no matching build iterators are given to end()
-         * and end() of a list.
-         */
-        RealmListIterators GetIteratorsForBuild(uint32 build) const;
-
-        /**
-         * Returns how many realms we have available for the current build
-         * @param build the build we want to know number of available realms for
-         * @return the number of available realms
-         */
-        uint32 NumRealmsForBuild(uint32 build) const;
+        RealmListView GetRealmsForBuild(uint32 build) const;
 
         /**
          * @return the total number of realms available
-         * \see RealmList::NumRealmsForBuild
          */
-        uint32 size() const { return m_realms.size(); };
+        uint32 size() const
+        {
+            return static_cast<uint32>(m_snapshots.Load()->realms.size());
+        }
     private:
         /**
          * Checks what version (ie, vanilla, tbc) a certain build number belongs to
@@ -196,9 +99,9 @@ class RealmList
          * @param realm the realm you want to add to the sorted list, should be done for all realms
          * \see RealmVersion
          */
-        void AddRealmToBuildList(const Realm& realm);
+        void AddRealmToBuildList(RealmSnapshot& snapshot, Realm const& realm);
 
-        void UpdateRealms(bool init);
+        std::shared_ptr<RealmSnapshot> BuildSnapshot(bool init);
 
         /**
          * @brief
@@ -214,13 +117,11 @@ class RealmList
          * @param popu
          * @param builds
          */
-        void UpdateRealm(uint32 ID, const std::string& name, RealmAddress const& address, RealmAddress const& localAddress, RealmAddress const& localSubnetmask, uint32 port, uint8 icon, RealmFlags realmflags, uint8 timezone, AccountTypes allowedSecurityLevel, float popu, const std::string& builds);
+        void UpdateRealm(RealmSnapshot& snapshot, uint32 ID, const std::string& name, RealmAddress const& address, RealmAddress const& localAddress, RealmAddress const& localSubnetmask, uint32 port, uint8 icon, RealmFlags realmflags, uint8 timezone, AccountTypes allowedSecurityLevel, float popu, const std::string& builds);
     private:
-        RealmMap m_realms;                                    ///< Internal map of realms
-        RealmStlList m_realmsByVersion[REALM_VERSION_COUNT]; ///< This sorts the realms by their supported build
+        RealmSnapshotStore m_snapshots;
+        RealmRefreshGate m_refreshGate;
         RealmBuildVersionMap m_buildToVersion;
-        uint32   m_UpdateInterval;
-        time_t   m_NextUpdateTime;
 };
 
 #define sRealmList RealmList::Instance()

--- a/Realm/RealmSnapshot.h
+++ b/Realm/RealmSnapshot.h
@@ -1,0 +1,175 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef MANGOS_H_REALMSNAPSHOT
+#define MANGOS_H_REALMSNAPSHOT
+
+#include "Common/ServerDefines.h"
+#include "Platform/Define.h"
+
+#include <array>
+#include <atomic>
+#include <ctime>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <utility>
+
+struct RealmAddress
+{
+    uint32 ip = 0;
+    uint16 port = 0;
+    bool loopback = false;
+};
+
+struct RealmBuildInfo
+{
+    int build;
+    int major_version;
+    int minor_version;
+    int bugfix_version;
+    int hotfix_version;
+};
+
+enum RealmVersion
+{
+    REALM_VERSION_VANILLA     = 0,
+    REALM_VERSION_TBC         = 1,
+    REALM_VERSION_WOTLK       = 2,
+    REALM_VERSION_CATA        = 3,
+    REALM_VERSION_MOP         = 4,
+    REALM_VERSION_WOD         = 5,
+    REALM_VERSION_LEGION      = 6,
+    REALM_VERSION_BFA         = 7,
+    REALM_VERSION_SHADOWLANDS = 8,
+    REALM_VERSION_COUNT       = 9
+};
+
+RealmBuildInfo const* FindBuildInfo(uint16 build);
+
+using RealmBuilds = std::set<uint32>;
+
+struct Realm
+{
+    std::string name;
+    RealmAddress ExternalAddress;
+    RealmAddress LocalAddress;
+    RealmAddress LocalSubnetMask;
+    uint8 icon;
+    RealmFlags realmflags;
+    uint8 timezone;
+    uint32 m_ID;
+    AccountTypes allowedSecurityLevel;
+    float populationLevel;
+    RealmBuilds realmbuilds;
+    RealmBuildInfo realmBuildInfo;
+};
+
+using RealmMap = std::map<std::string, Realm>;
+using RealmStlList = std::list<Realm const*>;
+
+struct RealmSnapshot
+{
+    RealmMap realms;
+    std::array<RealmStlList, REALM_VERSION_COUNT> realmsByVersion;
+};
+
+class RealmSnapshotStore
+{
+public:
+    using SnapshotPtr = std::shared_ptr<RealmSnapshot const>;
+
+    RealmSnapshotStore()
+        : m_snapshot(std::make_shared<RealmSnapshot>())
+    {
+    }
+
+    SnapshotPtr Load() const
+    {
+        return std::atomic_load_explicit(
+            &m_snapshot, std::memory_order_acquire);
+    }
+
+    void Publish(std::shared_ptr<RealmSnapshot> snapshot)
+    {
+        SnapshotPtr immutable = std::move(snapshot);
+        std::atomic_store_explicit(
+            &m_snapshot, std::move(immutable), std::memory_order_release);
+    }
+
+private:
+    SnapshotPtr m_snapshot;
+};
+
+class RealmListView
+{
+public:
+    using const_iterator = RealmStlList::const_iterator;
+
+    RealmListView(
+        RealmSnapshotStore::SnapshotPtr snapshot,
+        RealmVersion version)
+        : m_snapshot(std::move(snapshot)),
+          m_realms(&m_snapshot->realmsByVersion[
+              static_cast<std::size_t>(version)])
+    {
+    }
+
+    const_iterator begin() const { return m_realms->begin(); }
+    const_iterator end() const { return m_realms->end(); }
+    std::size_t size() const { return m_realms->size(); }
+    bool empty() const { return m_realms->empty(); }
+
+private:
+    RealmSnapshotStore::SnapshotPtr m_snapshot;
+    RealmStlList const* m_realms;
+};
+
+class RealmRefreshGate
+{
+public:
+    RealmRefreshGate(uint32 interval = 0, time_t nextUpdate = 0)
+        : m_interval(interval), m_nextUpdate(nextUpdate)
+    {
+    }
+
+    void Reset(uint32 interval, time_t nextUpdate)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_interval = interval;
+        m_nextUpdate = nextUpdate;
+    }
+
+    template<class Refresh>
+    bool RunIfDue(time_t now, Refresh&& refresh)
+    {
+        std::unique_lock<std::mutex> lock(m_mutex, std::try_to_lock);
+        if (!lock || !m_interval || m_nextUpdate > now)
+        {
+            return false;
+        }
+
+        m_nextUpdate = now + m_interval;
+        std::forward<Refresh>(refresh)();
+        return true;
+    }
+
+private:
+    std::mutex m_mutex;
+    uint32 m_interval;
+    time_t m_nextUpdate;
+};
+
+#endif

--- a/Tests/CheckAuthSafety.cmake
+++ b/Tests/CheckAuthSafety.cmake
@@ -1,0 +1,21 @@
+file(READ "${REALMD_SOURCE}/Auth/AuthSocket.cpp" AUTH_SOCKET)
+
+foreach(FORBIDDEN_TEXT "FLUSH TABLES" "keyVerified")
+  string(FIND "${AUTH_SOCKET}" "${FORBIDDEN_TEXT}" POSITION)
+  if(NOT POSITION EQUAL -1)
+    message(FATAL_ERROR
+      "Forbidden auth publication pattern remains: ${FORBIDDEN_TEXT}")
+  endif()
+endforeach()
+
+string(FIND "${AUTH_SOCKET}"
+  "if (!LoginDatabase.DirectPExecute(" CHECKED_UPDATE)
+if(CHECKED_UPDATE EQUAL -1)
+  message(FATAL_ERROR "Session-key update is not checked synchronously")
+endif()
+
+string(FIND "${AUTH_SOCKET}" "SendProof(sha);" SEND_PROOF)
+if(SEND_PROOF EQUAL -1 OR CHECKED_UPDATE GREATER SEND_PROOF)
+  message(FATAL_ERROR
+    "Successful proof can precede checked session-key publication")
+endif()

--- a/Tests/CheckPatchSafety.cmake
+++ b/Tests/CheckPatchSafety.cmake
@@ -1,0 +1,64 @@
+file(READ "${REALMD_SOURCE}/Auth/AuthSocket.cpp" AUTH_SOCKET)
+file(READ "${REALMD_SOURCE}/Auth/AuthSocket.h" AUTH_SOCKET_HEADER)
+file(READ "${REALMD_SOURCE}/Auth/PatchHandler.cpp" PATCH_HANDLER)
+file(READ "${REALMD_SOURCE}/Auth/PatchHandler.h" PATCH_HANDLER_HEADER)
+file(READ "${REALMD_SOURCE}/Main.cpp" MAIN_SOURCE)
+file(READ "${REALMD_SOURCE}/realmd.conf.dist.in" REALMD_CONFIG)
+
+set(PATCH_SOURCES
+  "${AUTH_SOCKET}\n${AUTH_SOCKET_HEADER}\n${PATCH_HANDLER}\n${PATCH_HANDLER_HEADER}")
+
+foreach(FORBIDDEN_TEXT
+    "class PatchCache"
+    "GetMD5("
+    "_patchPath"
+    "StartPatchTransfer(m_sender, m_closer, m_flowControl, _patchPath")
+  string(FIND "${PATCH_SOURCES}" "${FORBIDDEN_TEXT}" POSITION)
+  if(NOT POSITION EQUAL -1)
+    message(FATAL_ERROR
+      "Forbidden patch delivery pattern remains: ${FORBIDDEN_TEXT}")
+  endif()
+endforeach()
+
+foreach(REQUIRED_TEXT
+    "std::unique_ptr<PatchArtifact>"
+    "startOffset > artifact->size()"
+    "PatchArtifact::Open"
+    "_patchArtifact")
+  string(FIND "${PATCH_SOURCES}" "${REQUIRED_TEXT}" POSITION)
+  if(POSITION EQUAL -1)
+    message(FATAL_ERROR
+      "Required retained-artifact pattern is missing: ${REQUIRED_TEXT}")
+  endif()
+endforeach()
+
+string(FIND "${AUTH_SOCKET}"
+  "if (!memcmp(M.AsByteArray(), lp.M1, 20))" VERIFIED_PROOF)
+string(FIND "${AUTH_SOCKET}"
+  "_patchPolicy.ShouldPatch" PATCH_DECISION)
+if(VERIFIED_PROOF EQUAL -1 OR
+   PATCH_DECISION EQUAL -1 OR
+   PATCH_DECISION LESS VERIFIED_PROOF)
+  message(FATAL_ERROR
+    "Patch selection must occur after successful SRP proof verification")
+endif()
+
+string(FIND "${AUTH_SOCKET}" "if (!artifact)" MISSING_ARTIFACT)
+if(MISSING_ARTIFACT EQUAL -1)
+  message(FATAL_ERROR "Missing patch artifacts are not handled explicitly")
+endif()
+string(SUBSTRING "${AUTH_SOCKET}" ${MISSING_ARTIFACT} 500 MISSING_BRANCH)
+string(FIND "${MISSING_BRANCH}" "SendInvalidVersion();" INVALID_VERSION)
+string(FIND "${MISSING_BRANCH}" "return true;" BRANCH_RETURN)
+if(INVALID_VERSION EQUAL -1 OR
+   BRANCH_RETURN EQUAL -1 OR
+   INVALID_VERSION GREATER BRANCH_RETURN)
+  message(FATAL_ERROR
+    "Missing required patches must send invalid-version before returning")
+endif()
+
+string(FIND "${MAIN_SOURCE}" "Patch.ForceBuilds" FORCE_CONFIG_READ)
+string(FIND "${REALMD_CONFIG}" "Patch.ForceBuilds" FORCE_CONFIG_DOC)
+if(FORCE_CONFIG_READ EQUAL -1 OR FORCE_CONFIG_DOC EQUAL -1)
+  message(FATAL_ERROR "Patch.ForceBuilds is not wired and documented")
+endif()

--- a/Tests/PatchSafetyTests.cpp
+++ b/Tests/PatchSafetyTests.cpp
@@ -1,0 +1,168 @@
+#include "Auth/PatchArtifact.h"
+#include "Auth/PatchPolicy.h"
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <system_error>
+
+namespace
+{
+int failures = 0;
+
+#define CHECK(condition)                                                        \
+    do                                                                          \
+    {                                                                           \
+        if (!(condition))                                                       \
+        {                                                                       \
+            std::cerr << __FILE__ << ':' << __LINE__                            \
+                      << ": check failed: " #condition << '\n';                 \
+            ++failures;                                                         \
+        }                                                                       \
+    } while (false)
+
+void TestDefaultPolicyOnlyPatchesUnsupportedBuilds()
+{
+    auto policy = PatchPolicy::Parse(true, "");
+    CHECK(policy.has_value());
+    CHECK(policy->ShouldPatch(5000, false));
+    CHECK(!policy->ShouldPatch(5875, true));
+}
+
+void TestForcedPolicyMatchesExactAcceptedBuilds()
+{
+    auto policy = PatchPolicy::Parse(true, "5875 6005");
+    CHECK(policy.has_value());
+    CHECK(policy->ShouldPatch(5875, true));
+    CHECK(policy->ShouldPatch(6005, true));
+    CHECK(!policy->ShouldPatch(6141, true));
+}
+
+void TestDisabledPolicyNeverPatches()
+{
+    auto policy = PatchPolicy::Parse(false, "5875");
+    CHECK(policy.has_value());
+    CHECK(!policy->ShouldPatch(5000, false));
+    CHECK(!policy->ShouldPatch(5875, true));
+}
+
+void TestInvalidBuildTokensAreRejected()
+{
+    CHECK(!PatchPolicy::Parse(true, "0").has_value());
+    CHECK(!PatchPolicy::Parse(true, "65536").has_value());
+    CHECK(!PatchPolicy::Parse(true, "5875x").has_value());
+}
+
+std::string Hex(
+    std::array<std::uint8_t, MD5_DIGEST_LENGTH> const& digest)
+{
+    std::ostringstream hex;
+    hex << std::hex << std::setfill('0');
+    for (std::uint8_t byte : digest)
+    {
+        hex << std::setw(2) << static_cast<unsigned int>(byte);
+    }
+    return hex.str();
+}
+
+std::string ReadAll(PatchArtifact& artifact)
+{
+    std::string contents;
+    std::array<std::uint8_t, 8> buffer{};
+    for (;;)
+    {
+        std::streamsize const read =
+            artifact.Read(buffer.data(), buffer.size());
+        if (read <= 0)
+        {
+            break;
+        }
+        contents.append(
+            reinterpret_cast<char const*>(buffer.data()),
+            static_cast<std::size_t>(read));
+    }
+    return contents;
+}
+
+std::filesystem::path UniqueTempPath(char const* suffix)
+{
+    auto const nonce =
+        std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    return std::filesystem::temp_directory_path() /
+        ("realmd-patch-artifact-" + std::to_string(nonce) + suffix);
+}
+
+void TestArtifactRetainsSizeDigestAndBytes()
+{
+    std::filesystem::path const path = UniqueTempPath(".mpq");
+    {
+        std::ofstream output(path, std::ios::binary);
+        output << "abcdef";
+    }
+
+    auto artifact = PatchArtifact::Open(path.string());
+    CHECK(artifact != nullptr);
+    if (artifact)
+    {
+        CHECK(artifact->size() == 6);
+        CHECK(Hex(artifact->digest()) ==
+            "e80b5017098950fc58aad83c8c14978e");
+
+        CHECK(artifact->Seek(0));
+        CHECK(ReadAll(*artifact) == "abcdef");
+        CHECK(artifact->Seek(3));
+        CHECK(ReadAll(*artifact) == "def");
+        CHECK(artifact->Seek(artifact->size()));
+        CHECK(ReadAll(*artifact).empty());
+        CHECK(!artifact->Seek(artifact->size() + 1));
+    }
+
+    artifact.reset();
+    std::error_code cleanupError;
+    bool const removed = std::filesystem::remove(path, cleanupError);
+    CHECK(removed && !cleanupError);
+}
+
+void TestArtifactRejectsInvalidSources()
+{
+    std::filesystem::path const missing = UniqueTempPath("-missing.mpq");
+    CHECK(PatchArtifact::Open(missing.string()) == nullptr);
+    CHECK(PatchArtifact::Open(
+        std::filesystem::temp_directory_path().string()) == nullptr);
+
+    std::filesystem::path const empty = UniqueTempPath("-empty.mpq");
+    {
+        std::ofstream output(empty, std::ios::binary);
+    }
+    CHECK(PatchArtifact::Open(empty.string()) == nullptr);
+    std::error_code cleanupError;
+    bool const removed = std::filesystem::remove(empty, cleanupError);
+    CHECK(removed && !cleanupError);
+}
+}
+
+int main()
+{
+    TestDefaultPolicyOnlyPatchesUnsupportedBuilds();
+    TestForcedPolicyMatchesExactAcceptedBuilds();
+    TestDisabledPolicyNeverPatches();
+    TestInvalidBuildTokensAreRejected();
+    TestArtifactRetainsSizeDigestAndBytes();
+    TestArtifactRejectsInvalidSources();
+
+    if (failures != 0)
+    {
+        std::cerr << failures << " patch safety check(s) failed\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Patch safety checks passed\n";
+    return EXIT_SUCCESS;
+}

--- a/Tests/RealmSnapshotTests.cpp
+++ b/Tests/RealmSnapshotTests.cpp
@@ -1,0 +1,181 @@
+#include "Realm/RealmSnapshot.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+int failures = 0;
+
+#define CHECK(condition)                                                        \
+    do                                                                          \
+    {                                                                           \
+        if (!(condition))                                                       \
+        {                                                                       \
+            std::cerr << __FILE__ << ':' << __LINE__                            \
+                      << ": check failed: " #condition << '\n';                 \
+            ++failures;                                                         \
+        }                                                                       \
+    } while (false)
+
+std::shared_ptr<RealmSnapshot> MakeSnapshot(std::string const& name, uint32 id)
+{
+    auto snapshot = std::make_shared<RealmSnapshot>();
+    auto [realm, inserted] = snapshot->realms.emplace(name, Realm{});
+    CHECK(inserted);
+    realm->second.name = name;
+    realm->second.m_ID = id;
+    snapshot->realmsByVersion[REALM_VERSION_VANILLA].push_back(&realm->second);
+    return snapshot;
+}
+
+void TestViewRetainsPublishedGeneration()
+{
+    RealmSnapshotStore store;
+    store.Publish(MakeSnapshot("First", 1));
+    RealmListView oldView(store.Load(), REALM_VERSION_VANILLA);
+
+    store.Publish(MakeSnapshot("Second", 2));
+
+    CHECK(oldView.size() == 1);
+    CHECK((*oldView.begin())->name == "First");
+
+    RealmListView newView(store.Load(), REALM_VERSION_VANILLA);
+    CHECK(newView.size() == 1);
+    CHECK((*newView.begin())->name == "Second");
+}
+
+void TestConcurrentPublicationIsConsistent()
+{
+    RealmSnapshotStore store;
+    store.Publish(MakeSnapshot("Realm-0", 0));
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> done{false};
+    std::atomic<int> inconsistencies{0};
+
+    std::thread publisher([&]
+    {
+        while (!start.load(std::memory_order_acquire))
+        {
+        }
+
+        for (uint32 generation = 1; generation <= 2000; ++generation)
+        {
+            store.Publish(MakeSnapshot(
+                "Realm-" + std::to_string(generation), generation));
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    std::vector<std::thread> readers;
+    for (int reader = 0; reader < 4; ++reader)
+    {
+        readers.emplace_back([&]
+        {
+            start.store(true, std::memory_order_release);
+            do
+            {
+                RealmListView view(store.Load(), REALM_VERSION_VANILLA);
+                if (view.size() != 1)
+                {
+                    inconsistencies.fetch_add(1, std::memory_order_relaxed);
+                    continue;
+                }
+
+                Realm const* realm = *view.begin();
+                std::string const expected =
+                    "Realm-" + std::to_string(realm->m_ID);
+                if (realm->name != expected)
+                {
+                    inconsistencies.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+            while (!done.load(std::memory_order_acquire));
+        });
+    }
+
+    publisher.join();
+    for (std::thread& reader : readers)
+    {
+        reader.join();
+    }
+
+    CHECK(inconsistencies.load() == 0);
+}
+
+void TestRefreshGateAdmitsOneCaller()
+{
+    RealmRefreshGate gate(20, 100);
+    std::atomic<int> entered{0};
+    std::vector<std::thread> callers;
+    for (int i = 0; i < 8; ++i)
+    {
+        callers.emplace_back([&]
+        {
+            gate.RunIfDue(100, [&] { entered.fetch_add(1); });
+        });
+    }
+    for (std::thread& caller : callers)
+    {
+        caller.join();
+    }
+    CHECK(entered.load() == 1);
+}
+
+void TestRefreshGateDoesNotBlockOtherCallers()
+{
+    RealmRefreshGate gate(20, 100);
+    std::promise<void> refreshEntered;
+    std::promise<void> releaseRefresh;
+    std::future<void> release = releaseRefresh.get_future();
+
+    std::thread owner([&]
+    {
+        gate.RunIfDue(100, [&]
+        {
+            refreshEntered.set_value();
+            release.wait();
+        });
+    });
+    refreshEntered.get_future().wait();
+
+    std::future<bool> concurrent = std::async(std::launch::async, [&]
+    {
+        return gate.RunIfDue(100, [] {});
+    });
+
+    bool const returnedImmediately =
+        concurrent.wait_for(std::chrono::milliseconds(100)) ==
+        std::future_status::ready;
+    CHECK(returnedImmediately);
+
+    releaseRefresh.set_value();
+    owner.join();
+    CHECK(!concurrent.get());
+}
+}
+
+int main()
+{
+    TestViewRetainsPublishedGeneration();
+    TestConcurrentPublicationIsConsistent();
+    TestRefreshGateAdmitsOneCaller();
+    TestRefreshGateDoesNotBlockOtherCallers();
+
+    if (failures != 0)
+    {
+        std::cerr << failures << " realm snapshot check(s) failed\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Realm snapshot checks passed\n";
+    return EXIT_SUCCESS;
+}

--- a/realmd.conf.dist.in
+++ b/realmd.conf.dist.in
@@ -41,6 +41,23 @@ ConfVersion=@MANGOS_REALM_VER@
 #        Default: 30
 #                 0 (Disabled)
 #
+#    Patch.Enable
+#        Allow realmd to offer build+locale MPQ upgrades to unsupported builds
+#        and builds selected by Patch.ForceBuilds.
+#        Default: 1
+#
+#    Patch.ForceBuilds
+#        Exact accepted source builds that must consume a staged upgrade before
+#        login. Whitespace-separated. Empty preserves normal accepted-build
+#        login.
+#        Stage each archive as ./patches/<build><locale>.mpq, for example
+#        ./patches/5875enUS.mpq. Build the complete publisher-signed MPQ outside
+#        that path and replace it atomically before offering it. Existing
+#        transfers retain the exact open artifact that was advertised.
+#        This mechanism upgrades client builds; it does not push same-build
+#        content updates.
+#        Default: ""
+#
 #    BindIP
 #        Bind realm list demon to IP/hostname
 #        DO NOT CHANGE THIS UNLESS YOU _REALLY_ KNOW WHAT YOU'RE DOING
@@ -137,6 +154,8 @@ PidFile                = ""
 MaxPingTime            = 30
 RealmServerPort        = 3724
 AuthSessionTimeout     = 30
+Patch.Enable           = 1
+Patch.ForceBuilds      = ""
 BindIP                 = "0.0.0.0"
 
 LogLevel               = 0


### PR DESCRIPTION
## Summary

Hardens three remaining login-path findings from the Classic client/realmd protocol audit:

- **F-03 — realm-state publication:** refreshes now build complete immutable snapshots and publish them atomically. Realm-list serialization owns one snapshot generation for both the advertised count and every record, while contended refresh callers continue on the last complete generation instead of waiting behind database work.
- **F-16 — session-key publication:** replaces the transaction/`FLUSH TABLES`/poll loop with one checked synchronous `DirectPExecute`. SQL failure closes the connection before `SendProof` or `STATUS_AUTHED`.
- **F-05/F-06 — patch delivery:** adds explicit `Patch.Enable` and exact-build `Patch.ForceBuilds` policy, moves patch selection behind successful SRP proof, validates resume offsets, and retains one open `PatchArtifact` for advertised size, MD5, and transferred bytes.

The default policy preserves existing behavior: patching remains enabled for unsupported builds, while accepted builds are unaffected unless explicitly listed in `Patch.ForceBuilds`.

## Why

The old realm list was cleared and rebuilt in shared mutable containers while login workers could hold iterators into it. Session publication used unchecked asynchronous-style statements plus a global table flush and polling loop, yet still allowed proof to proceed. Patch metadata was cached by pathname and the transfer reopened that pathname later, so staged-file replacement could make the advertised and transferred generations differ.

## Validation

- MaNGOS Zero Release `INSTALL` target: passed
- Complete Zero CTest suite: **12/12 passed**
- Installed `RealmdAuthStreamSmoke.ps1`: passed prompt rejection, fragmented challenge, live debug logging, idle timeout, and process-survival checks
- Build/install `realmd.exe` SHA256 matched: `943D084FDF9E0572D458AB3DE1CC2EA1B88E5878ACEE8DCEF17AF9FEFDB847B3`
- Focused coverage includes concurrent snapshot publication/lifetime, nonblocking refresh admission, exact patch-policy parsing, retained artifact size/MD5/seek/read behavior, auth publication ordering, and patch source-safety policy
- Read-only Claude correctness review: **APPROVE WITH FOLLOW-UP**, no BLOCKING or IMPORTANT findings

The implementation uses APIs available in MaNGOS Zero, One, and Two (`DirectPExecute`, `GetBoolDefault`, `GetStringDefault`, and C++17). The removed realm iterator/count API was private to realmd call sites.

## Deferred gate and operational notes

No publisher-signed Blizzard patch archive is currently staged, so actual end-to-end client download and ingestion remains a required follow-up smoke test once a valid archive is available. This change does not construct/sign archives or provide same-build content pushes.

An active retained patch handle may prevent replace-over-open-file on Windows. Operators should finish active transfers or restage/restart before the next offer if Windows refuses an atomic replacement; this does not allow advertised bytes to differ from transferred bytes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/31)
<!-- Reviewable:end -->
