### PR TITLE
Fix realmd test discovery across MaNGOS parents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,17 +87,11 @@ if(WIN32 AND MSVC)
         )
 endif()
 
-# Gated on WITH_TESTS: the project's single global test switch, declared at the
-# top level as option(WITH_TESTS "Build the unit tests" OFF). Tests are built
-# only when they are explicitly asked for, and an undefined WITH_TESTS evaluates
-# false, so the default is off either way.
-#
-# Deliberately NOT the CMake-standard BUILD_TESTING: include(CTest) defines that
-# as ON by default, so any dependency pulling CTest in would silently start
-# building tests project-wide. WITH_TESTS is also what gates enable_testing() at
-# the root, so gating on anything else leaves every add_test() below a no-op and
-# ctest reports "No tests were found".
-if(WITH_TESTS)
+# Parent cores use two explicit test switches: WITH_TESTS in MangosTwo and
+# BUILD_TESTING in MangosZero/MangosOne. Both default off in their respective
+# parents, so realmd tests remain opt-in while working with every supported
+# parent convention.
+if(WITH_TESTS OR BUILD_TESTING)
     add_executable(realmd_auth_protocol_tests
         Tests/AuthProtocolGuardTests.cpp
         Auth/AuthProtocolGuard.cpp


### PR DESCRIPTION
## What changed

- allow the shared realmd tests to follow either parent-core test switch
- keep test targets opt-in for every supported parent
- correct the CMake comment to document the Zero/One/Two conventions

## Why

PR #32 gated all realmd test targets only on `WITH_TESTS`. MangosZero enables focused regression tests with `BUILD_TESTING`, and MangosOne maps `BUILD_REGRESSION_TESTS` to `BUILD_TESTING`, so both parents silently discovered zero realmd tests. MangosTwo uses `WITH_TESTS`.

Using `WITH_TESTS OR BUILD_TESTING` preserves all three parent conventions without changing production behavior or default build settings.

## Validation

- reproduced on MangosZero before the change: `ctest -N -R ^realmd_` reported 0 tests with `BUILD_TESTING=ON`
- after the change: the same configure discovered all 5 realmd tests
- built the 3 realmd executable test targets in Release
- ran all 5 realmd tests: 5 passed, 0 failed
- confirmed the parent option definitions in MangosZero, MangosOne, and MangosTwo
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/33)
<!-- Reviewable:end -->
