### PR TITLE
Fix multi-client build policy and auth results

### DIFF
--- a/Auth/AuthResultPolicy.cpp
+++ b/Auth/AuthResultPolicy.cpp
@@ -1,0 +1,20 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * multiple client generations from one realmd process.
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ */
+
+#include "AuthResultPolicy.h"
+#include "Realm/ClientBuildPolicy.h"
+
+AuthResult LockedAccountResultForBuild(uint32 build)
+{
+    ClientBuildPolicy const* policy = FindClientBuildPolicy(build);
+    if (!policy || policy->realmVersion == REALM_VERSION_VANILLA)
+    {
+        return WOW_FAIL_DB_BUSY;
+    }
+
+    return WOW_FAIL_LOCKED_ENFORCED;
+}

--- a/Auth/AuthResultPolicy.h
+++ b/Auth/AuthResultPolicy.h
@@ -1,0 +1,16 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * multiple client generations from one realmd process.
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ */
+
+#ifndef MANGOS_H_AUTHRESULTPOLICY
+#define MANGOS_H_AUTHRESULTPOLICY
+
+#include "AuthCodes.h"
+#include "Platform/Define.h"
+
+AuthResult LockedAccountResultForBuild(uint32 build);
+
+#endif

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -56,6 +56,7 @@
 #include "AuthSocket.h"
 #include "AuthCodes.h"
 #include "AuthProtocolGuard.h"
+#include "AuthResultPolicy.h"
 #include "PatchArtifact.h"
 #include "PatchHandler.h"
 
@@ -610,11 +611,8 @@ bool AuthSocket::_HandleLogonChallenge()
                 if (strcmp((*result)[3].GetString(), get_remote_address().c_str()))
                 {
                     DEBUG_LOG("[AuthChallenge] Account IP differs");
-#if defined(CLASSIC)
-                    pkt << (uint8)WOW_FAIL_DB_BUSY;
-#else
-                    pkt << (uint8)WOW_FAIL_LOCKED_ENFORCED;
-#endif
+                    pkt << static_cast<uint8>(
+                        LockedAccountResultForBuild(_build));
                     locked = true;
                 }
                 else

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -51,6 +51,7 @@
 #include "Database/DatabaseEnv.h"
 #include "Config/Config.h"
 #include "Log.h"
+#include "Realm/ClientBuildPolicy.h"
 #include "Realm/RealmList.h"
 #include "AuthSocket.h"
 #include "AuthCodes.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,20 @@ if(WITH_TESTS OR BUILD_TESTING)
     )
     add_test(NAME realmd_realm_snapshot_tests COMMAND realmd_realm_snapshot_tests)
 
+    add_executable(realmd_client_build_policy_tests
+        Tests/ClientBuildPolicyTests.cpp
+        Realm/ClientBuildPolicy.cpp
+    )
+    target_compile_features(realmd_client_build_policy_tests PUBLIC cxx_std_17)
+    set_target_properties(realmd_client_build_policy_tests PROPERTIES CXX_EXTENSIONS OFF)
+    target_include_directories(realmd_client_build_policy_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(realmd_client_build_policy_tests PRIVATE
+        shared
+    )
+    add_test(NAME realmd_client_build_policy_tests COMMAND realmd_client_build_policy_tests)
+
     add_test(NAME realmd_auth_safety_policy
         COMMAND ${CMAKE_COMMAND}
             -DREALMD_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ if(WITH_TESTS OR BUILD_TESTING)
 
     add_executable(realmd_client_build_policy_tests
         Tests/ClientBuildPolicyTests.cpp
+        Auth/AuthResultPolicy.cpp
         Realm/ClientBuildPolicy.cpp
     )
     target_compile_features(realmd_client_build_policy_tests PUBLIC cxx_std_17)

--- a/Realm/ClientBuildPolicy.cpp
+++ b/Realm/ClientBuildPolicy.cpp
@@ -1,0 +1,46 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * multiple client generations from one realmd process.
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ */
+
+#include "ClientBuildPolicy.h"
+
+namespace
+{
+ClientBuildPolicy const SupportedClientBuilds[] =
+{
+    {{40000, 9, 0, 0, ' '}, REALM_VERSION_SHADOWLANDS},
+    {{35662, 8, 3, 7, ' '}, REALM_VERSION_BFA},
+    {{26972, 7, 3, 5, ' '}, REALM_VERSION_LEGION},
+    {{21742, 6, 2, 4, ' '}, REALM_VERSION_WOD},
+    {{18414, 5, 4, 8, ' '}, REALM_VERSION_MOP},
+    {{18273, 5, 4, 8, ' '}, REALM_VERSION_MOP},
+    {{15595, 4, 3, 4, ' '}, REALM_VERSION_CATA},
+    {{12340, 3, 3, 5, 'a'}, REALM_VERSION_WOTLK},
+    {{8606, 2, 4, 3, ' '}, REALM_VERSION_TBC},
+    {{6141, 1, 12, 3, ' '}, REALM_VERSION_VANILLA},
+    {{6005, 1, 12, 2, ' '}, REALM_VERSION_VANILLA},
+    {{5875, 1, 12, 1, ' '}, REALM_VERSION_VANILLA},
+};
+}
+
+ClientBuildPolicy const* FindClientBuildPolicy(uint32 build)
+{
+    for (ClientBuildPolicy const& policy : SupportedClientBuilds)
+    {
+        if (static_cast<uint32>(policy.buildInfo.build) == build)
+        {
+            return &policy;
+        }
+    }
+
+    return nullptr;
+}
+
+RealmBuildInfo const* FindBuildInfo(uint16 build)
+{
+    ClientBuildPolicy const* policy = FindClientBuildPolicy(build);
+    return policy ? &policy->buildInfo : nullptr;
+}

--- a/Realm/ClientBuildPolicy.h
+++ b/Realm/ClientBuildPolicy.h
@@ -1,0 +1,22 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * multiple client generations from one realmd process.
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ */
+
+#ifndef MANGOS_H_CLIENTBUILDPOLICY
+#define MANGOS_H_CLIENTBUILDPOLICY
+
+#include "RealmSnapshot.h"
+
+struct ClientBuildPolicy
+{
+    RealmBuildInfo buildInfo;
+    RealmVersion realmVersion;
+};
+
+ClientBuildPolicy const* FindClientBuildPolicy(uint32 build);
+RealmBuildInfo const* FindBuildInfo(uint16 build);
+
+#endif

--- a/Realm/RealmList.cpp
+++ b/Realm/RealmList.cpp
@@ -43,6 +43,7 @@
 #include "Platform/Define.h"
 #include <cstring>
 #include <string>
+#include "ClientBuildPolicy.h"
 #include "RealmList.h"
 #include "Auth/AuthCodes.h"
 #include "Util.h"                                           // for Tokens typedef
@@ -90,49 +91,6 @@ static RealmAddress ResolveRealmAddress(const std::string& host, uint16 port)
     return result;
 }
 
-// will only support WoW 1.12.1/1.12.2/1.12.3, WoW:TBC 2.4.3, WoW:WotLK 3.3.5a and official release for WoW:Cataclysm and later, client builds 15595, 10505, 8606, 6005, 5875
-// if you need more from old build then add it in cases in realmd sources code
-// list sorted from high to low build and first build used as low bound for accepted by default range (any > it will accepted by realmd at least)
-
-static const RealmBuildInfo ExpectedRealmdClientBuilds[] =
-{
-    // highest supported build, also auto accept all above for simplify future supported builds testing
-    {40000, 9, 0, 0, ' '},  // SHADOWLANDS
-    {35662, 8, 3, 7, ' '},  // BFA
-    {26972, 7, 3, 5, ' '},  // Legion
-    {21742, 6, 2, 4, ' '},  // WOD
-    {18414, 5, 4, 8, ' '},  // MOP
-    {18273, 5, 4, 8, ' '},  // MOP
-    {15595, 4, 3, 4, ' '},  // CATA
-    {12340, 3, 3, 5, 'a'},  // WOTLK
-    {8606,  2, 4, 3, ' '},  // TBC
-    {6141,  1, 12, 3, ' '}, // Vanilla - Chinese
-    {6005,  1, 12, 2, ' '}, // Vanilla - Spanish
-    {5875,  1, 12, 1, ' '}, // Vanilla
-    {0,     0, 0, 0, ' '}                                   // terminator
-};
-
-RealmBuildInfo const* FindBuildInfo(uint16 _build)
-{
-    // first build is low bound of always accepted range
-    if (_build >= ExpectedRealmdClientBuilds[0].build)
-    {
-        return &ExpectedRealmdClientBuilds[0];
-    }
-
-    // continue from 1 with explicit equal check
-    for (int i = 1; ExpectedRealmdClientBuilds[i].build; ++i)
-    {
-        if (_build == ExpectedRealmdClientBuilds[i].build)
-        {
-            return &ExpectedRealmdClientBuilds[i];
-        }
-    }
-
-    // none appropriate build
-    return NULL;
-}
-
 RealmList::RealmList()
 {
 }
@@ -145,15 +103,8 @@ RealmList& sRealmList
 
 RealmVersion RealmList::BelongsToVersion(uint32 build) const
 {
-    RealmBuildVersionMap::const_iterator it;
-    if ((it = m_buildToVersion.find(build)) != m_buildToVersion.end())
-    {
-        return it->second;
-    }
-    else
-    {
-        return REALM_VERSION_VANILLA;
-    }
+    ClientBuildPolicy const* policy = FindClientBuildPolicy(build);
+    return policy ? policy->realmVersion : REALM_VERSION_VANILLA;
 }
 
 RealmListView RealmList::GetRealmsForBuild(uint32 build) const
@@ -164,8 +115,6 @@ RealmListView RealmList::GetRealmsForBuild(uint32 build) const
 /// Load the realm list from the database
 void RealmList::Initialize(uint32 updateInterval)
 {
-    InitBuildToVersion();
-
     ///- Get the content of the realmlist table in the database
     m_snapshots.Publish(BuildSnapshot(true));
     m_refreshGate.Reset(updateInterval, time(NULL));
@@ -177,30 +126,6 @@ void RealmList::AddRealmToBuildList(
     RealmBuilds builds = realm.realmbuilds;
     int buildNumber = *(builds.begin());
     snapshot.realmsByVersion[BelongsToVersion(buildNumber)].push_back(&realm);
-}
-
-void RealmList::InitBuildToVersion()
-{
-    m_buildToVersion[5875] = REALM_VERSION_VANILLA;
-    m_buildToVersion[6005] = REALM_VERSION_VANILLA;
-    m_buildToVersion[6141] = REALM_VERSION_VANILLA;
-
-    m_buildToVersion[8606] = REALM_VERSION_TBC;
-
-    m_buildToVersion[12340] = REALM_VERSION_WOTLK;
-
-    m_buildToVersion[15595] = REALM_VERSION_CATA;
-
-    m_buildToVersion[18273] = REALM_VERSION_MOP;
-    m_buildToVersion[18414] = REALM_VERSION_MOP;
-
-    m_buildToVersion[21742] = REALM_VERSION_WOD;
-
-    m_buildToVersion[26972] = REALM_VERSION_LEGION;
-
-    m_buildToVersion[35662] = REALM_VERSION_BFA;
-
-    m_buildToVersion[40000] = REALM_VERSION_SHADOWLANDS;
 }
 
 void RealmList::UpdateRealm(

--- a/Realm/RealmList.h
+++ b/Realm/RealmList.h
@@ -33,7 +33,6 @@
 
 #include <memory>
 #include <string>
-#include <map>
 
 /**
  * @brief Storage object for the list of realms on the server
@@ -46,20 +45,12 @@ class RealmList
          * @brief
          *
          */
-        typedef std::map<uint32, RealmVersion> RealmBuildVersionMap;
-
         static RealmList& Instance();
 
         RealmList();
         ~RealmList() {};
 
         void Initialize(uint32 updateInterval);
-
-        /**
-         * Initializes a map holding a link from build number to a version.
-         * \see RealmVersion
-         */
-        void InitVersionToBuild();
 
         void UpdateIfNeed();
 
@@ -79,13 +70,6 @@ class RealmList
          * @return the corresponding version to the given build number
          */
         RealmVersion BelongsToVersion(uint32 build) const;
-
-        /**
-         * Adds entries to a map containing a link from a build number to a certain
-         * wow version, ie: \ref RealmVersion::REALM_VERSION_VANILLA.
-         * \see RealmVersion
-         */
-        void InitBuildToVersion();
 
         /**
          * Adds the given \ref Realm to a list sorted by version, ie: vanilla, tbc etc. This
@@ -121,7 +105,6 @@ class RealmList
     private:
         RealmSnapshotStore m_snapshots;
         RealmRefreshGate m_refreshGate;
-        RealmBuildVersionMap m_buildToVersion;
 };
 
 #define sRealmList RealmList::Instance()

--- a/Realm/RealmSnapshot.h
+++ b/Realm/RealmSnapshot.h
@@ -57,8 +57,6 @@ enum RealmVersion
     REALM_VERSION_COUNT       = 9
 };
 
-RealmBuildInfo const* FindBuildInfo(uint16 build);
-
 using RealmBuilds = std::set<uint32>;
 
 struct Realm

--- a/Tests/ClientBuildPolicyTests.cpp
+++ b/Tests/ClientBuildPolicyTests.cpp
@@ -1,0 +1,94 @@
+#include "Realm/ClientBuildPolicy.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace
+{
+int failures = 0;
+
+#define CHECK(condition)                                                        \
+    do                                                                          \
+    {                                                                           \
+        if (!(condition))                                                       \
+        {                                                                       \
+            std::cerr << __FILE__ << ':' << __LINE__                            \
+                      << ": check failed: " #condition << '\n';                 \
+            ++failures;                                                         \
+        }                                                                       \
+    } while (false)
+
+struct ExpectedBuild
+{
+    uint32 build;
+    RealmVersion version;
+    int major;
+    int minor;
+    int bugfix;
+    int hotfix;
+};
+
+void TestSupportedBuildsResolveExactly()
+{
+    ExpectedBuild const supported[] =
+    {
+        {5875, REALM_VERSION_VANILLA, 1, 12, 1, ' '},
+        {6005, REALM_VERSION_VANILLA, 1, 12, 2, ' '},
+        {6141, REALM_VERSION_VANILLA, 1, 12, 3, ' '},
+        {8606, REALM_VERSION_TBC, 2, 4, 3, ' '},
+        {12340, REALM_VERSION_WOTLK, 3, 3, 5, 'a'},
+        {15595, REALM_VERSION_CATA, 4, 3, 4, ' '},
+        {18273, REALM_VERSION_MOP, 5, 4, 8, ' '},
+        {18414, REALM_VERSION_MOP, 5, 4, 8, ' '},
+        {21742, REALM_VERSION_WOD, 6, 2, 4, ' '},
+        {26972, REALM_VERSION_LEGION, 7, 3, 5, ' '},
+        {35662, REALM_VERSION_BFA, 8, 3, 7, ' '},
+        {40000, REALM_VERSION_SHADOWLANDS, 9, 0, 0, ' '},
+    };
+
+    for (ExpectedBuild const& expected : supported)
+    {
+        ClientBuildPolicy const* policy =
+            FindClientBuildPolicy(expected.build);
+        CHECK(policy != nullptr);
+        if (!policy)
+        {
+            continue;
+        }
+
+        CHECK(policy->realmVersion == expected.version);
+        CHECK(policy->buildInfo.build == static_cast<int>(expected.build));
+        CHECK(policy->buildInfo.major_version == expected.major);
+        CHECK(policy->buildInfo.minor_version == expected.minor);
+        CHECK(policy->buildInfo.bugfix_version == expected.bugfix);
+        CHECK(policy->buildInfo.hotfix_version == expected.hotfix);
+        CHECK(FindBuildInfo(static_cast<uint16>(expected.build)) ==
+              &policy->buildInfo);
+    }
+}
+
+void TestUnknownBuildsAreRejected()
+{
+    uint32 const unsupported[] = {0, 1, 39999, 40001, 65535};
+    for (uint32 build : unsupported)
+    {
+        CHECK(FindClientBuildPolicy(build) == nullptr);
+        CHECK(FindBuildInfo(static_cast<uint16>(build)) == nullptr);
+    }
+}
+}
+
+int main()
+{
+    TestSupportedBuildsResolveExactly();
+    TestUnknownBuildsAreRejected();
+
+    if (failures != 0)
+    {
+        std::cerr << failures << " client build policy check(s) failed\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Client build policy checks passed\n";
+    return EXIT_SUCCESS;
+}

--- a/Tests/ClientBuildPolicyTests.cpp
+++ b/Tests/ClientBuildPolicyTests.cpp
@@ -1,3 +1,4 @@
+#include "Auth/AuthResultPolicy.h"
 #include "Realm/ClientBuildPolicy.h"
 
 #include <cstdlib>
@@ -76,12 +77,39 @@ void TestUnknownBuildsAreRejected()
         CHECK(FindBuildInfo(static_cast<uint16>(build)) == nullptr);
     }
 }
+
+void TestLockedAccountResultUsesRuntimeBuildFamily()
+{
+    uint32 const vanilla[] = {5875, 6005, 6141};
+    for (uint32 build : vanilla)
+    {
+        CHECK(LockedAccountResultForBuild(build) == WOW_FAIL_DB_BUSY);
+    }
+
+    uint32 const later[] =
+    {
+        8606, 12340, 15595, 18273, 18414, 21742,
+        26972, 35662, 40000
+    };
+    for (uint32 build : later)
+    {
+        CHECK(LockedAccountResultForBuild(build) ==
+              WOW_FAIL_LOCKED_ENFORCED);
+    }
+
+    uint32 const unknown[] = {0, 39999, 40001, 65535};
+    for (uint32 build : unknown)
+    {
+        CHECK(LockedAccountResultForBuild(build) == WOW_FAIL_DB_BUSY);
+    }
+}
 }
 
 int main()
 {
     TestSupportedBuildsResolveExactly();
     TestUnknownBuildsAreRejected();
+    TestLockedAccountResultUsesRuntimeBuildFamily();
 
     if (failures != 0)
     {


### PR DESCRIPTION
## Summary

- require client builds to match an explicit supported-build entry
- centralize supported-build lookup for realm-list compatibility
- select authentication failure results from the connecting client's protocol generation instead of compile-time core settings
- add focused build-policy and auth-result coverage

## Why

The shared realmd serves clients from Classic through Mists of Pandaria. Build acceptance previously relied on broad numeric ranges, while some authentication responses were selected at compile time. That could admit unknown builds or return a result value from the wrong client protocol generation.

## Impact

Supported MaNGOS client generations continue to authenticate through one realmd instance. Unknown builds are rejected unless configured for patch delivery, and locked-account responses use the protocol expected by the connecting client.

## Validation

- Release build and install completed in the MaNGOS Zero Testing checkout
- CTest: 13/13 passed
- deployed executable matched the tested build by SHA-256
- live login/realm-list smoke tests passed for:
  - MaNGOS Zero / Classic
  - MaNGOS One / The Burning Crusade
  - MaNGOS Two / Wrath of the Lich King
  - MaNGOS Three / Cataclysm
  - MaNGOS Four / Mists of Pandaria

## Follow-up

Cataclysm realm-list Cancel navigation will be investigated separately; it is outside this authentication/build-policy change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/34)
<!-- Reviewable:end -->
