### PR TITLE
Harden canonical authentication packet framing

### DIFF
--- a/Auth/AuthProtocolGuard.cpp
+++ b/Auth/AuthProtocolGuard.cpp
@@ -27,6 +27,14 @@ bool IsState(StreamState actual, StreamState expected)
 {
     return actual == expected;
 }
+
+constexpr std::size_t ChallengeAccountPrefixBodySize = 30;
+constexpr std::size_t ChallengeAccountLengthOffset =
+    AuthChallengeHeaderSize + ChallengeAccountPrefixBodySize - 1;
+constexpr std::size_t ChallengeAccountDataOffset =
+    ChallengeAccountLengthOffset + 1;
+constexpr std::size_t LogonProofKeyCountOffset = 73;
+constexpr std::size_t ReconnectProofKeyCountOffset = 57;
 }
 
 FrameDecision InspectFrame(
@@ -72,13 +80,46 @@ FrameDecision InspectFrame(
             }
 
             required = AuthChallengeHeaderSize + body;
-            break;
+            if (size < required)
+            {
+                return {FrameStatus::Incomplete, RejectReason::None, required};
+            }
+
+            std::uint8_t const accountLength =
+                data[ChallengeAccountLengthOffset];
+            if (body != ChallengeAccountPrefixBodySize + accountLength)
+            {
+                return Reject(RejectReason::MalformedLength);
+            }
+
+            for (std::size_t i = 0; i < accountLength; ++i)
+            {
+                if (data[ChallengeAccountDataOffset + i] == 0)
+                {
+                    return Reject(RejectReason::MalformedLength);
+                }
+            }
+
+            return {FrameStatus::Complete, RejectReason::None, required};
         }
         case CMD_AUTH_LOGON_PROOF:
         {
             if (!IsState(state, StreamState::LogonProof))
             {
                 return Reject(RejectReason::UnauthorizedCommand);
+            }
+            if (size <= LogonProofKeyCountOffset)
+            {
+                return
+                {
+                    FrameStatus::Incomplete,
+                    RejectReason::None,
+                    LogonProofKeyCountOffset + 1
+                };
+            }
+            if (data[LogonProofKeyCountOffset] != 0)
+            {
+                return Reject(RejectReason::UnsupportedKeyProof);
             }
             required = AuthLogonProofSize;
             break;
@@ -88,6 +129,19 @@ FrameDecision InspectFrame(
             if (!IsState(state, StreamState::ReconnectProof))
             {
                 return Reject(RejectReason::UnauthorizedCommand);
+            }
+            if (size <= ReconnectProofKeyCountOffset)
+            {
+                return
+                {
+                    FrameStatus::Incomplete,
+                    RejectReason::None,
+                    ReconnectProofKeyCountOffset + 1
+                };
+            }
+            if (data[ReconnectProofKeyCountOffset] != 0)
+            {
+                return Reject(RejectReason::UnsupportedKeyProof);
             }
             required = AuthReconnectProofSize;
             break;

--- a/Auth/AuthProtocolGuard.h
+++ b/Auth/AuthProtocolGuard.h
@@ -43,7 +43,8 @@ enum class RejectReason
     None,
     UnknownCommand,
     UnauthorizedCommand,
-    MalformedLength
+    MalformedLength,
+    UnsupportedKeyProof
 };
 
 struct FrameDecision

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -558,7 +558,7 @@ bool AuthSocket::_HandleLogonChallenge()
 
     ByteBuffer pkt;
 
-    _login = (const char*)ch->I;
+    _login.assign(reinterpret_cast<char const*>(ch->I), ch->I_len);
     _build = ch->build;
     _os = (const char*)ch->os;
 
@@ -970,7 +970,7 @@ bool AuthSocket::_HandleReconnectChallenge()
     DEBUG_LOG("[ReconnectChallenge] got full packet, %#04x bytes", ch->size);
     DEBUG_LOG("[ReconnectChallenge] name(%d): '%s'", ch->I_len, ch->I);
 
-    _login = (const char*)ch->I;
+    _login.assign(reinterpret_cast<char const*>(ch->I), ch->I_len);
 
     _safelogin = _login;
     LoginDatabase.escape_string(_safelogin);

--- a/Tests/AuthProtocolGuardTests.cpp
+++ b/Tests/AuthProtocolGuardTests.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <iostream>
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace
@@ -34,11 +35,16 @@ using MaNGOS::Auth::MaxPendingInput;
 using MaNGOS::Auth::RejectReason;
 using MaNGOS::Auth::StreamState;
 
+constexpr std::size_t ChallengeAccountLengthOffset = 33;
+constexpr std::size_t ChallengeAccountDataOffset = 34;
+constexpr std::size_t ChallengeAccountPrefixBodySize = 30;
+
 std::vector<std::uint8_t> MakeChallenge(std::uint8_t command,
                                         std::uint16_t build,
-                                        std::uint16_t bodySize =
-                                            AuthChallengeMinimumBodySize)
+                                        std::string const& account = "TEST")
 {
+    std::uint16_t const bodySize = static_cast<std::uint16_t>(
+        ChallengeAccountPrefixBodySize + account.size());
     std::vector<std::uint8_t> frame(AuthChallengeHeaderSize + bodySize, 0);
     frame[0] = command;
     frame[2] = static_cast<std::uint8_t>(bodySize & 0xFF);
@@ -49,7 +55,21 @@ std::vector<std::uint8_t> MakeChallenge(std::uint8_t command,
         frame[11] = static_cast<std::uint8_t>(build & 0xFF);
         frame[12] = static_cast<std::uint8_t>(build >> 8);
     }
+    frame[ChallengeAccountLengthOffset] =
+        static_cast<std::uint8_t>(account.size());
+    for (std::size_t i = 0; i < account.size(); ++i)
+    {
+        frame[ChallengeAccountDataOffset + i] =
+            static_cast<std::uint8_t>(account[i]);
+    }
     return frame;
+}
+
+void SetChallengeBodySize(std::vector<std::uint8_t>& frame,
+                          std::uint16_t bodySize)
+{
+    frame[2] = static_cast<std::uint8_t>(bodySize & 0xFF);
+    frame[3] = static_cast<std::uint8_t>(bodySize >> 8);
 }
 
 void CheckChallengeSplits(std::uint8_t command)
@@ -93,6 +113,21 @@ void CheckFixedFrame(StreamState state, std::uint8_t command,
     CHECK(complete.frameSize == required);
 }
 
+void CheckProofFrame(StreamState state, std::uint8_t command,
+                     std::size_t required, std::size_t keyCountOffset)
+{
+    CheckFixedFrame(state, command, required);
+
+    std::vector<std::uint8_t> nonZeroKeyCount(required, 0);
+    nonZeroKeyCount[0] = command;
+    nonZeroKeyCount[keyCountOffset] = 1;
+
+    auto const decision = InspectFrame(
+        state, nonZeroKeyCount.data(), keyCountOffset + 1);
+    CHECK(decision.status == FrameStatus::Reject);
+    CHECK(decision.reason == RejectReason::UnsupportedKeyProof);
+}
+
 void CheckChallengeFraming()
 {
     CheckChallengeSplits(CMD_AUTH_LOGON_CHALLENGE);
@@ -101,21 +136,59 @@ void CheckChallengeFraming()
     for (std::uint16_t body = 0;
          body < AuthChallengeMinimumBodySize; ++body)
     {
-        std::vector<std::uint8_t> const frame =
-            MakeChallenge(CMD_AUTH_LOGON_CHALLENGE, 5875, body);
+        std::vector<std::uint8_t> frame =
+            MakeChallenge(CMD_AUTH_LOGON_CHALLENGE, 5875);
+        SetChallengeBodySize(frame, body);
         auto const decision =
             InspectFrame(StreamState::Challenge, frame.data(), frame.size());
         CHECK(decision.status == FrameStatus::Reject);
         CHECK(decision.reason == RejectReason::MalformedLength);
     }
+
+    std::vector<std::uint8_t> shortBody =
+        MakeChallenge(CMD_AUTH_LOGON_CHALLENGE, 5875);
+    SetChallengeBodySize(
+        shortBody,
+        static_cast<std::uint16_t>(
+            ChallengeAccountPrefixBodySize +
+            shortBody[ChallengeAccountLengthOffset] - 1));
+    auto decision =
+        InspectFrame(StreamState::Challenge, shortBody.data(), shortBody.size());
+    CHECK(decision.status == FrameStatus::Reject);
+    CHECK(decision.reason == RejectReason::MalformedLength);
+
+    std::vector<std::uint8_t> longBody =
+        MakeChallenge(CMD_AUTH_LOGON_CHALLENGE, 5875);
+    std::uint16_t const declaredLongBody = static_cast<std::uint16_t>(
+        ChallengeAccountPrefixBodySize +
+        longBody[ChallengeAccountLengthOffset] + 1);
+    SetChallengeBodySize(longBody, declaredLongBody);
+    longBody.resize(AuthChallengeHeaderSize + declaredLongBody);
+    decision =
+        InspectFrame(StreamState::Challenge, longBody.data(), longBody.size());
+    CHECK(decision.status == FrameStatus::Reject);
+    CHECK(decision.reason == RejectReason::MalformedLength);
+
+    std::vector<std::uint8_t> embeddedNul =
+        MakeChallenge(
+            CMD_AUTH_LOGON_CHALLENGE, 5875, std::string("TE\0ST", 5));
+    decision = InspectFrame(
+        StreamState::Challenge, embeddedNul.data(), embeddedNul.size());
+    CHECK(decision.status == FrameStatus::Reject);
 }
 
 void CheckFixedFraming()
 {
-    CheckFixedFrame(StreamState::LogonProof, CMD_AUTH_LOGON_PROOF,
-                    MaNGOS::Auth::AuthLogonProofSize);
-    CheckFixedFrame(StreamState::ReconnectProof, CMD_AUTH_RECONNECT_PROOF,
-                    MaNGOS::Auth::AuthReconnectProofSize);
+    CheckProofFrame(
+        StreamState::LogonProof,
+        CMD_AUTH_LOGON_PROOF,
+        MaNGOS::Auth::AuthLogonProofSize,
+        73);
+    CheckProofFrame(
+        StreamState::ReconnectProof,
+        CMD_AUTH_RECONNECT_PROOF,
+        MaNGOS::Auth::AuthReconnectProofSize,
+        57);
     CheckFixedFrame(StreamState::Authenticated, CMD_REALM_LIST,
                     MaNGOS::Auth::AuthRealmListSize);
     CheckFixedFrame(StreamState::Patch, CMD_XFER_ACCEPT,


### PR DESCRIPTION
## Summary

- require logon and reconnect challenge frames to match the account-name length declared in the packet
- reject embedded NUL bytes in account names and assign the validated account using its explicit length
- reject unsupported non-zero proof key counts before the fixed proof handlers run
- add regression coverage for every challenge split, malformed account-length combinations, embedded NULs, and proof key-count handling

## Why

The frame guard previously trusted the challenge packet's overall body size without requiring it to agree with the account-name length field. The proof guard also treated proof packets as fixed-size frames without first rejecting the variable key-record form that realmd does not implement. That could allow malformed or unsupported packet layouts to reach handlers under incorrect framing assumptions.

The updated guard accepts only the canonical packet forms handled by realmd and rejects unsupported key proofs before handler parsing.

## Impact

Normal zero-key authentication frames remain unchanged. Malformed challenge frames and proof packets containing unsupported key records are now rejected at the protocol boundary instead of being interpreted by fixed-layout handlers.

## Validation

- `cmake --build E:\Mangos\WIP\Zero\Testing\server_build --config Release --target realmd -- /m`
- `ctest --test-dir E:\Mangos\WIP\Zero\Testing\server_build -C Release --output-on-failure`
- 13/13 configured tests passed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/35)
<!-- Reviewable:end -->
