### PR TITLE
Stop demanding an OpenSSL provider realmd never used

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -61,8 +61,6 @@
 
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
-#include <openssl/provider.h>
-#include "Auth/OpenSSLProvider.h"
 
 #include <chrono>
 #include <cstring>
@@ -425,14 +423,6 @@ extern int main(int argc, char** argv)
     LoadScheduledExitConfig();
 
     DETAIL_LOG("Using SSL version: %s (Library: %s)", OPENSSL_VERSION_TEXT, OpenSSL_version(OPENSSL_VERSION));
-
-    // RAII provider management - automatically handles cleanup
-    OpenSSLProviderManager providerManager;
-    if (!providerManager.IsInitialized())
-    {
-        Log::WaitBeforeContinueIfNeed();
-        return 1;
-    }
 
     /// realmd PID file creation
     std::string pidfile = sConfig.GetStringDefault("PidFile", "");


### PR DESCRIPTION
The login daemon refused to start unless the OpenSSL legacy provider could be loaded. It never needed it. RC4 was the only algorithm anywhere in these trees that lived outside the default provider, it belonged to the world server's packet crypt and to Warden, and it has just been implemented in the core itself -- so the check here was guarding a dependency realmd did not have, and the header it reached for no longer exists.

SRP6, SHA-1 and the bignum work are all default-provider algorithms, compiled into libcrypto. They were never at risk and are not affected.

What goes away with these ten lines is a deployment requirement: ossl-modules/legacy.dll beside the binary, an OPENSSL_MODULES search path, and an installer obliged to ship a module OpenSSL has deprecated and will one day remove -- at which point this daemon would have stopped booting.

Linking is unchanged and still dynamic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/39)
<!-- Reviewable:end -->
