### PR TITLE
Preserve exact authenticated client locale

### DIFF
--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -585,7 +585,6 @@ bool AuthSocket::_HandleLogonChallenge()
     EndianConvert(*((uint32*)(&ch->gamename[0])));
     EndianConvert(ch->build);
     EndianConvert(*((uint32*)(&ch->platform[0])));
-    EndianConvert(*((uint32*)(&ch->os[0])));
     EndianConvert(ch->timezone_bias);
     EndianConvert(ch->ip);
 

--- a/Auth/AuthSocket.cpp
+++ b/Auth/AuthSocket.cpp
@@ -57,6 +57,7 @@
 #include "AuthCodes.h"
 #include "AuthProtocolGuard.h"
 #include "AuthResultPolicy.h"
+#include "ClientLocale.h"
 #include "PatchArtifact.h"
 #include "PatchHandler.h"
 
@@ -576,13 +577,15 @@ bool AuthSocket::_HandleLogonChallenge()
     DEBUG_LOG("[AuthChallenge] got full packet, %#04x bytes", ch->size);
     DEBUG_LOG("[AuthChallenge] name(%d): '%s'", ch->I_len, ch->I);
 
+    auto const clientLocale = MaNGOS::Auth::ParseClientLocaleClaim(
+        std::string_view(reinterpret_cast<char const*>(ch->country), 4));
+
     // BigEndian code, nop in little endian case
     // size already converted
     EndianConvert(*((uint32*)(&ch->gamename[0])));
     EndianConvert(ch->build);
     EndianConvert(*((uint32*)(&ch->platform[0])));
     EndianConvert(*((uint32*)(&ch->os[0])));
-    EndianConvert(*((uint32*)(&ch->country[0])));
     EndianConvert(ch->timezone_bias);
     EndianConvert(ch->ip);
 
@@ -746,13 +749,12 @@ bool AuthSocket::_HandleLogonChallenge()
                     uint8 secLevel = (*result)[4].GetUInt8();
                     _accountSecurityLevel = secLevel <= SEC_ADMINISTRATOR ? AccountTypes(secLevel) : SEC_ADMINISTRATOR;
 
-                    _localizationName.resize(4);
-                    for (int i = 0; i < 4; ++i)
-                    {
-                        _localizationName[i] = ch->country[4 - i - 1];
-                    }
-
-                    BASIC_LOG("[AuthChallenge] account %s is using '%c%c%c%c' locale (%u)", _login.c_str(), ch->country[3], ch->country[2], ch->country[1], ch->country[0], GetLocaleByName(_localizationName));
+                    _localizationName = clientLocale.value_or(std::string{});
+                    BASIC_LOG("[AuthChallenge] account %s is using '%s' locale (%u)",
+                        _login.c_str(),
+                        _localizationName.empty() ? "invalid" :
+                            _localizationName.c_str(),
+                        GetLocaleByName(_localizationName));
 
                     _status = STATUS_LOGON_PROOF;
                 }
@@ -881,17 +883,23 @@ bool AuthSocket::_HandleLogonProof()
         }
 
         ///- Update the sessionkey, last_ip, last login time and reset number of failed logins in the account table for this account
-        // No SQL injection (escaped user name and OS) and IP address as received by socket
+        // Locale and OS are escaped, the account name was escaped during the
+        // challenge, and the transport supplies the peer IP address.
         const char* K_hex = K.AsHexStr();
+        std::string safeLocale = _localizationName;
 
+        LoginDatabase.escape_string(safeLocale);
         LoginDatabase.escape_string(_os);
         if (!LoginDatabase.DirectPExecute(
             "UPDATE `account` SET `sessionkey` = '%s', `last_ip` = '%s', "
-            "`last_login` = NOW(), `locale` = '%u', `os` = '%s', "
+            "`last_login` = NOW(), `locale` = '%u', "
+            "`client_locale` = NULLIF('%s', ''), "
+            "`os` = '%s', "
             "`failed_logins` = 0 WHERE `username` = '%s'",
             K_hex,
             get_remote_address().c_str(),
             GetLocaleByName(_localizationName),
+            safeLocale.c_str(),
             _os.c_str(),
             _safelogin.c_str()))
         {
@@ -1012,6 +1020,9 @@ bool AuthSocket::_HandleReconnectChallenge()
     DEBUG_LOG("[ReconnectChallenge] got full packet, %#04x bytes", ch->size);
     DEBUG_LOG("[ReconnectChallenge] name(%d): '%s'", ch->I_len, ch->I);
 
+    auto const clientLocale = MaNGOS::Auth::ParseClientLocaleClaim(
+        std::string_view(reinterpret_cast<char const*>(ch->country), 4));
+
     _login.assign(reinterpret_cast<char const*>(ch->I), ch->I_len);
 
     _safelogin = _login;
@@ -1019,6 +1030,7 @@ bool AuthSocket::_HandleReconnectChallenge()
 
     EndianConvert(ch->build);
     _build = ch->build;
+    _localizationName = clientLocale.value_or(std::string{});
     _os = (const char*)ch->os;
 
     if (_os.size() > 4)
@@ -1087,6 +1099,22 @@ bool AuthSocket::_HandleReconnectProof()
 
     if (!memcmp(sha.GetDigest(), lp.R2, SHA_DIGEST_LENGTH))
     {
+        std::string safeLocale = _localizationName;
+        std::string safeOs = _os;
+        LoginDatabase.escape_string(safeLocale);
+        LoginDatabase.escape_string(safeOs);
+        if (!LoginDatabase.DirectPExecute(
+            "UPDATE `account` SET `client_locale` = NULLIF('%s', ''), "
+            "`os` = '%s' WHERE `username` = '%s'",
+            safeLocale.c_str(), safeOs.c_str(), _safelogin.c_str()))
+        {
+            sLog.outError(
+                "[Auth] Failed to publish reconnect client identity for "
+                "account %s", _login.c_str());
+            close_connection();
+            return false;
+        }
+
         ///- Sending response
         ByteBuffer pkt;
         pkt << (uint8)  CMD_AUTH_RECONNECT_PROOF;

--- a/Auth/ClientLocale.cpp
+++ b/Auth/ClientLocale.cpp
@@ -1,0 +1,45 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "Auth/ClientLocale.h"
+
+#include <utility>
+
+namespace MaNGOS::Auth
+{
+std::optional<std::string> ParseClientLocaleClaim(std::string_view wireLocale)
+{
+    if (wireLocale.size() != 4)
+    {
+        return std::nullopt;
+    }
+
+    std::string locale(wireLocale.rbegin(), wireLocale.rend());
+    bool const canonical =
+        locale[0] >= 'a' && locale[0] <= 'z' &&
+        locale[1] >= 'a' && locale[1] <= 'z' &&
+        locale[2] >= 'A' && locale[2] <= 'Z' &&
+        locale[3] >= 'A' && locale[3] <= 'Z';
+    return canonical ? std::optional<std::string>(std::move(locale)) :
+        std::nullopt;
+}
+}

--- a/Auth/ClientLocale.h
+++ b/Auth/ClientLocale.h
@@ -1,0 +1,41 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MANGOS_AUTH_CLIENT_LOCALE_H
+#define MANGOS_AUTH_CLIENT_LOCALE_H
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace MaNGOS::Auth
+{
+/**
+ * Parses the reversed four-byte locale field from an authentication challenge.
+ *
+ * The returned claim is syntax-validated but is not treated as a supported
+ * world locale. Each world core owns that later profile decision.
+ */
+std::optional<std::string> ParseClientLocaleClaim(std::string_view wireLocale);
+}
+
+#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ if(WITH_TESTS OR BUILD_TESTING)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
     target_link_libraries(realmd_patch_safety_tests PRIVATE
+        shared
         mangos_openssl
         mangos_openssl_strict
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,17 @@ endif()
 # parents, so realmd tests remain opt-in while working with every supported
 # parent convention.
 if(WITH_TESTS OR BUILD_TESTING)
+    add_executable(realmd_client_locale_tests
+        Tests/ClientLocaleTests.cpp
+        Auth/ClientLocale.cpp
+    )
+    target_compile_features(realmd_client_locale_tests PUBLIC cxx_std_17)
+    set_target_properties(realmd_client_locale_tests PROPERTIES CXX_EXTENSIONS OFF)
+    target_include_directories(realmd_client_locale_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    add_test(NAME realmd_client_locale_tests COMMAND realmd_client_locale_tests)
+
     add_executable(realmd_auth_protocol_tests
         Tests/AuthProtocolGuardTests.cpp
         Auth/AuthProtocolGuard.cpp

--- a/Tests/CheckAuthSafety.cmake
+++ b/Tests/CheckAuthSafety.cmake
@@ -1,15 +1,7 @@
 file(READ "${REALMD_SOURCE}/Auth/AuthSocket.cpp" AUTH_SOCKET)
 
-function(require_count HAYSTACK NEEDLE EXPECTED MESSAGE_TEXT)
-  string(REGEX MATCHALL "${NEEDLE}" MATCHES "${HAYSTACK}")
-  list(LENGTH MATCHES ACTUAL)
-  if(NOT ACTUAL EQUAL EXPECTED)
-    message(FATAL_ERROR
-      "${MESSAGE_TEXT}: expected ${EXPECTED}, found ${ACTUAL}")
-  endif()
-endfunction()
-
-foreach(FORBIDDEN_TEXT "FLUSH TABLES" "keyVerified" "GetExactLocaleName")
+foreach(FORBIDDEN_TEXT "FLUSH TABLES" "keyVerified" "GetExactLocaleName"
+    "EndianConvert(*((uint32*)(&ch->os[0])))")
   string(FIND "${AUTH_SOCKET}" "${FORBIDDEN_TEXT}" POSITION)
   if(NOT POSITION EQUAL -1)
     message(FATAL_ERROR
@@ -17,37 +9,65 @@ foreach(FORBIDDEN_TEXT "FLUSH TABLES" "keyVerified" "GetExactLocaleName")
   endif()
 endforeach()
 
-require_count("${AUTH_SOCKET}" "ParseClientLocaleClaim" 2
-  "Both authentication challenges must parse the exact locale claim")
-require_count("${AUTH_SOCKET}" "NULLIF\\('%s',[ ]*''\\)" 2
-  "Both successful proof paths must publish invalid locale as SQL NULL")
-require_count("${AUTH_SOCKET}" "if \\(\\!LoginDatabase\\.DirectPExecute\\(" 2
-  "Both successful proof paths must check locale publication synchronously")
-
 string(FIND "${AUTH_SOCKET}"
-  "if (!LoginDatabase.DirectPExecute(" CHECKED_UPDATE)
-if(CHECKED_UPDATE EQUAL -1)
-  message(FATAL_ERROR "Session-key update is not checked synchronously")
-endif()
-
-string(FIND "${AUTH_SOCKET}" "SendProof(sha);" SEND_PROOF)
-if(SEND_PROOF EQUAL -1 OR CHECKED_UPDATE GREATER SEND_PROOF)
-  message(FATAL_ERROR
-    "Successful proof can precede checked session-key publication")
-endif()
-
+  "bool AuthSocket::_HandleLogonChallenge()" LOGON_CHALLENGE)
+string(FIND "${AUTH_SOCKET}"
+  "bool AuthSocket::_HandleLogonProof()" LOGON_PROOF)
+string(FIND "${AUTH_SOCKET}"
+  "bool AuthSocket::_HandleReconnectChallenge()" RECONNECT_CHALLENGE)
 string(FIND "${AUTH_SOCKET}"
   "bool AuthSocket::_HandleReconnectProof()" RECONNECT_PROOF)
-if(RECONNECT_PROOF EQUAL -1)
-  message(FATAL_ERROR "Reconnect proof handler is missing")
+if(LOGON_CHALLENGE EQUAL -1 OR LOGON_PROOF EQUAL -1 OR
+   RECONNECT_CHALLENGE EQUAL -1 OR RECONNECT_PROOF EQUAL -1)
+  message(FATAL_ERROR "An authentication handler is missing")
 endif()
+
+math(EXPR LOGON_CHALLENGE_LENGTH "${LOGON_PROOF} - ${LOGON_CHALLENGE}")
+string(SUBSTRING "${AUTH_SOCKET}" ${LOGON_CHALLENGE}
+  ${LOGON_CHALLENGE_LENGTH} LOGON_CHALLENGE_BODY)
+string(FIND "${LOGON_CHALLENGE_BODY}"
+  "ParseClientLocaleClaim" LOGON_PARSE)
+if(LOGON_PARSE EQUAL -1)
+  message(FATAL_ERROR "Logon challenge does not parse the exact locale claim")
+endif()
+
+math(EXPR LOGON_PROOF_LENGTH "${RECONNECT_CHALLENGE} - ${LOGON_PROOF}")
+string(SUBSTRING "${AUTH_SOCKET}" ${LOGON_PROOF}
+  ${LOGON_PROOF_LENGTH} LOGON_PROOF_BODY)
+string(FIND "${LOGON_PROOF_BODY}"
+  "if (!LoginDatabase.DirectPExecute(" LOGON_UPDATE)
+string(FIND "${LOGON_PROOF_BODY}"
+  "`client_locale` = NULLIF('%s', '')" LOGON_NULL_LOCALE)
+string(FIND "${LOGON_PROOF_BODY}" "SendProof(sha);" LOGON_SUCCESS)
+if(LOGON_UPDATE EQUAL -1 OR LOGON_NULL_LOCALE EQUAL -1 OR
+   LOGON_SUCCESS EQUAL -1 OR LOGON_UPDATE GREATER LOGON_NULL_LOCALE OR
+   LOGON_NULL_LOCALE GREATER LOGON_SUCCESS)
+  message(FATAL_ERROR
+    "Logon success can precede checked nullable locale publication")
+endif()
+
+math(EXPR RECONNECT_CHALLENGE_LENGTH
+  "${RECONNECT_PROOF} - ${RECONNECT_CHALLENGE}")
+string(SUBSTRING "${AUTH_SOCKET}" ${RECONNECT_CHALLENGE}
+  ${RECONNECT_CHALLENGE_LENGTH} RECONNECT_CHALLENGE_BODY)
+string(FIND "${RECONNECT_CHALLENGE_BODY}"
+  "ParseClientLocaleClaim" RECONNECT_PARSE)
+if(RECONNECT_PARSE EQUAL -1)
+  message(FATAL_ERROR
+    "Reconnect challenge does not parse the exact locale claim")
+endif()
+
 string(SUBSTRING "${AUTH_SOCKET}" ${RECONNECT_PROOF} -1 RECONNECT_BODY)
 string(FIND "${RECONNECT_BODY}"
   "if (!LoginDatabase.DirectPExecute(" RECONNECT_UPDATE)
 string(FIND "${RECONNECT_BODY}"
+  "`client_locale` = NULLIF('%s', '')" RECONNECT_NULL_LOCALE)
+string(FIND "${RECONNECT_BODY}"
   "send((char const*)pkt.contents(), pkt.size());" RECONNECT_SUCCESS)
-if(RECONNECT_UPDATE EQUAL -1 OR RECONNECT_SUCCESS EQUAL -1 OR
-   RECONNECT_UPDATE GREATER RECONNECT_SUCCESS)
+if(RECONNECT_UPDATE EQUAL -1 OR RECONNECT_NULL_LOCALE EQUAL -1 OR
+   RECONNECT_SUCCESS EQUAL -1 OR
+   RECONNECT_UPDATE GREATER RECONNECT_NULL_LOCALE OR
+   RECONNECT_NULL_LOCALE GREATER RECONNECT_SUCCESS)
   message(FATAL_ERROR
-    "Reconnect success can precede checked locale and OS publication")
+    "Reconnect success can precede checked nullable locale publication")
 endif()

--- a/Tests/CheckAuthSafety.cmake
+++ b/Tests/CheckAuthSafety.cmake
@@ -1,12 +1,28 @@
 file(READ "${REALMD_SOURCE}/Auth/AuthSocket.cpp" AUTH_SOCKET)
 
-foreach(FORBIDDEN_TEXT "FLUSH TABLES" "keyVerified")
+function(require_count HAYSTACK NEEDLE EXPECTED MESSAGE_TEXT)
+  string(REGEX MATCHALL "${NEEDLE}" MATCHES "${HAYSTACK}")
+  list(LENGTH MATCHES ACTUAL)
+  if(NOT ACTUAL EQUAL EXPECTED)
+    message(FATAL_ERROR
+      "${MESSAGE_TEXT}: expected ${EXPECTED}, found ${ACTUAL}")
+  endif()
+endfunction()
+
+foreach(FORBIDDEN_TEXT "FLUSH TABLES" "keyVerified" "GetExactLocaleName")
   string(FIND "${AUTH_SOCKET}" "${FORBIDDEN_TEXT}" POSITION)
   if(NOT POSITION EQUAL -1)
     message(FATAL_ERROR
       "Forbidden auth publication pattern remains: ${FORBIDDEN_TEXT}")
   endif()
 endforeach()
+
+require_count("${AUTH_SOCKET}" "ParseClientLocaleClaim" 2
+  "Both authentication challenges must parse the exact locale claim")
+require_count("${AUTH_SOCKET}" "NULLIF\\('%s',[ ]*''\\)" 2
+  "Both successful proof paths must publish invalid locale as SQL NULL")
+require_count("${AUTH_SOCKET}" "if \\(\\!LoginDatabase\\.DirectPExecute\\(" 2
+  "Both successful proof paths must check locale publication synchronously")
 
 string(FIND "${AUTH_SOCKET}"
   "if (!LoginDatabase.DirectPExecute(" CHECKED_UPDATE)
@@ -18,4 +34,20 @@ string(FIND "${AUTH_SOCKET}" "SendProof(sha);" SEND_PROOF)
 if(SEND_PROOF EQUAL -1 OR CHECKED_UPDATE GREATER SEND_PROOF)
   message(FATAL_ERROR
     "Successful proof can precede checked session-key publication")
+endif()
+
+string(FIND "${AUTH_SOCKET}"
+  "bool AuthSocket::_HandleReconnectProof()" RECONNECT_PROOF)
+if(RECONNECT_PROOF EQUAL -1)
+  message(FATAL_ERROR "Reconnect proof handler is missing")
+endif()
+string(SUBSTRING "${AUTH_SOCKET}" ${RECONNECT_PROOF} -1 RECONNECT_BODY)
+string(FIND "${RECONNECT_BODY}"
+  "if (!LoginDatabase.DirectPExecute(" RECONNECT_UPDATE)
+string(FIND "${RECONNECT_BODY}"
+  "send((char const*)pkt.contents(), pkt.size());" RECONNECT_SUCCESS)
+if(RECONNECT_UPDATE EQUAL -1 OR RECONNECT_SUCCESS EQUAL -1 OR
+   RECONNECT_UPDATE GREATER RECONNECT_SUCCESS)
+  message(FATAL_ERROR
+    "Reconnect success can precede checked locale and OS publication")
 endif()

--- a/Tests/ClientLocaleTests.cpp
+++ b/Tests/ClientLocaleTests.cpp
@@ -1,0 +1,92 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "Auth/ClientLocale.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace
+{
+int failures = 0;
+
+#define CHECK(condition)                                                        \
+    do                                                                          \
+    {                                                                           \
+        if (!(condition))                                                       \
+        {                                                                       \
+            std::cerr << __FILE__ << ':' << __LINE__                            \
+                      << ": check failed: " #condition << '\n';                 \
+            ++failures;                                                         \
+        }                                                                       \
+    } while (false)
+
+void CheckAccepted(std::string const& wire, char const* expected)
+{
+    auto const parsed = MaNGOS::Auth::ParseClientLocaleClaim(wire);
+    CHECK(parsed.has_value());
+    if (parsed)
+    {
+        CHECK(*parsed == expected);
+    }
+}
+void CheckRejected(std::string const& wire)
+{
+    CHECK(!MaNGOS::Auth::ParseClientLocaleClaim(wire).has_value());
+}
+
+void TestCanonicalClaimsArePreserved()
+{
+    CheckAccepted("SUne", "enUS");
+    CheckAccepted("BGne", "enGB");
+    CheckAccepted("NChz", "zhCN");
+    CheckAccepted("RBtp", "ptBR");
+    CheckAccepted("URur", "ruRU");
+}
+
+void TestMalformedClaimsAreRejected()
+{
+    CheckRejected("");
+    CheckRejected("SUn");
+    CheckRejected("SUneX");
+    CheckRejected("sune");
+    CheckRejected("SU'X");
+    CheckRejected("SU1e");
+    CheckRejected(std::string("SU\0e", 4));
+}
+}
+
+int main()
+{
+    TestCanonicalClaimsArePreserved();
+    TestMalformedClaimsAreRejected();
+
+    if (failures != 0)
+    {
+        std::cerr << failures << " client locale check(s) failed\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Client locale checks passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- persist the exact authenticated four-byte client locale alongside the existing numeric locale
- preserve unknown-but-valid locale identity as `none` instead of inventing a supported locale
- retain the current numeric locale behavior for existing consumers

## Why

The numeric locale mapping collapses client tokens that the core does not recognize. Warden profile admission needs the exact authenticated build/platform/locale tuple so unsupported clients cannot silently inherit another profile's checks.

## Dependency

Requires the `client_locale` Realm schema introduced by [mangos/Realm_DB#10](https://github.com/mangos/Realm_DB/pull/10).

## Validation

- rebased onto current `realmd` master, including SRP6-width and OpenSSL-provider fixes
- `range-diff` confirmed both locale commits remained patch-equivalent
- RelWithDebInfo server build passed
- 10/10 selected realmd/protocol/build/Warden integration gates passed
- 130/130 Warden tests and the database-version test passed in the consuming server

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/realmd/40)
<!-- Reviewable:end -->
